### PR TITLE
change namespace

### DIFF
--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_AudioLink_Static.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_AudioLink_Static.cs
@@ -4,7 +4,7 @@ using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
 using VRC.Udon;
-using VRCAudioLink;
+using AudioLink;
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
 using UnityEditor;


### PR DESCRIPTION
we are changing the namespace in the next version of audiolink.

you could go for a smarter solution with defines based on version.
0.3.x and below are `VRCAudioLink`, 1.x.x will be `AudioLink`