### PR TITLE
Update VRSL 2.4.x vpmDependencies for AudioLink

### DIFF
--- a/Packages/com.acchosen.vr-stage-lighting/package.json
+++ b/Packages/com.acchosen.vr-stage-lighting/package.json
@@ -9,7 +9,7 @@
   },
   "gitDependencies": {},
   "vpmDependencies": {
-    "com.llealloo.audiolink": ">=0.3.1 <1.0.0 || =1.2.0"
+    "com.llealloo.audiolink": "~0.3.1 || ~1.2.0"
   },
   "legacyFolders": {
     "Assets\\VR-Stage-Lighting": ""

--- a/Packages/com.acchosen.vr-stage-lighting/package.json
+++ b/Packages/com.acchosen.vr-stage-lighting/package.json
@@ -9,7 +9,7 @@
   },
   "gitDependencies": {},
   "vpmDependencies": {
-    "com.llealloo.audiolink": ">=0.3.1"
+    "com.llealloo.audiolink": ">=1.2.0"
   },
   "legacyFolders": {
     "Assets\\VR-Stage-Lighting": ""

--- a/Packages/com.acchosen.vr-stage-lighting/package.json
+++ b/Packages/com.acchosen.vr-stage-lighting/package.json
@@ -9,7 +9,7 @@
   },
   "gitDependencies": {},
   "vpmDependencies": {
-    "com.llealloo.audiolink": ">=1.2.0"
+    "com.llealloo.audiolink": ">=0.3.1 <1.0.0 || =1.2.0"
   },
   "legacyFolders": {
     "Assets\\VR-Stage-Lighting": ""

--- a/Packages/com.acchosen.vr-stage-lighting/package.json
+++ b/Packages/com.acchosen.vr-stage-lighting/package.json
@@ -9,7 +9,7 @@
   },
   "gitDependencies": {},
   "vpmDependencies": {
-    "com.llealloo.audiolink": "~0.3.1 || ~1.2.0"
+    "com.llealloo.audiolink": "0.3.x || >=1.2.0"
   },
   "legacyFolders": {
     "Assets\\VR-Stage-Lighting": ""


### PR DESCRIPTION
AudioLink 1.0.0 and 1,1.0 are not recommended for use by the AudioLink team, so VRSL 2.4.x releases should strictly require 0.3.x or at least 1.2.x 