### PR TITLE
fix audiolink laser handling in VRSL_ManagerWindow.cs

### DIFF
--- a/Packages/com.acchosen.vr-stage-lighting/Editor/VRSL_ManagerWindow.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Editor/VRSL_ManagerWindow.cs
@@ -577,9 +577,9 @@ public class AudioLinkListItem
         laser.ApplyProxyModifications();
         #pragma warning restore 0618 //suppressing obsoletion warnings
 
-        if(PrefabUtility.IsPartOfAnyPrefab(light))
+        if(PrefabUtility.IsPartOfAnyPrefab(laser))
         {
-            PrefabUtility.RecordPrefabInstancePropertyModifications(light);
+            PrefabUtility.RecordPrefabInstancePropertyModifications(laser);
         }
     }
 
@@ -4193,6 +4193,10 @@ public class VRSL_ManagerWindow : EditorWindow {
                                         EditorGUILayout.EndFoldoutHeaderGroup();
                                     }
                                 }
+                                if(fixture.isLaser && PrefabUtility.IsPartOfAnyPrefab(fixture.laser))
+                                {
+                                    PrefabUtility.RecordPrefabInstancePropertyModifications(fixture.laser);
+                                } else
                                 if(PrefabUtility.IsPartOfAnyPrefab(fixture.light))
                                 {
                                     PrefabUtility.RecordPrefabInstancePropertyModifications(fixture.light);


### PR DESCRIPTION
Fixes #39
If there is an audiolink laser in the scene and the user either:
- Tries to `Update Fixtures` in the VRSL Control Panel
- Tries to open an audiolink band in the UI

The console will print and error or spam errors respectively.

This change prevents the errors without change in functionality.

For more images, check my Discord Messages here (VRSL/Club Orion): https://discordapp.com/channels/855872620917293066/855876755633471529/1296624717783896106