### PR TITLE
Add UdonSharp checks and adjust accordingly

### DIFF
--- a/Packages/com.acchosen.vr-stage-lighting/Editor/VRSL_ManagerWindow.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Editor/VRSL_ManagerWindow.cs
@@ -1,10 +1,12 @@
-using UdonSharp;
 using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
 using UnityEngine.UI;
 using System.Threading;
 using VRSL;
+
+#if UDONSHARP
+using UdonSharp;
+using VRC.SDKBase;
+using VRC.Udon;
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
 using UnityEditor;
@@ -20,9 +22,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using UnityEngine.UIElements;
 using System.IO;
-#endif
-#if !COMPILER_UDONSHARP && UNITY_EDITOR
-
 
 namespace VRSL.EditorScripts
 {
@@ -4312,4 +4311,6 @@ public class VRSL_ManagerWindow : EditorWindow {
     }
 }
 }
+#endif
+
 #endif

--- a/Packages/com.acchosen.vr-stage-lighting/Editor/VRSL_UdonEditor.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Editor/VRSL_UdonEditor.cs
@@ -1,25 +1,30 @@
-﻿using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
+﻿using UnityEngine;
 using UnityEngine.UI;
 using System.Threading;
+
+#if UDONSHARP
+using UdonSharp;
+using VRC.SDKBase;
+using VRC.Udon;
 using VRC.SDKBase.Midi;
 
-
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
-using UnityEditor;
 using UdonSharpEditor;
-using UnityEngine.SceneManagement;
 //using VRC.Udon;
 using VRC.Udon.Common;
 using VRC.Udon.Common.Interfaces;
+#endif
+
+#endif
+
+#if !COMPILER_UDONSHARP && UNITY_EDITOR
+using UnityEditor;
+using UnityEngine.SceneManagement;
 using System.Collections.Immutable;
 using System;
 using System.IO;
 using System.Collections.Generic;
 #endif
-
 
 namespace VRSL.EditorScripts
 {
@@ -201,7 +206,9 @@ namespace VRSL.EditorScripts
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
+#if UDONSHARP
             if (UdonSharpGUI.DrawDefaultUdonSharpBehaviourHeader(target)) return;
+#endif
             DrawLogo();
             ShurikenHeaderCentered(GetVersion());
             EditorGUILayout.Space();
@@ -407,7 +414,9 @@ namespace VRSL.EditorScripts
 
         public override void OnInspectorGUI()
         {
+#if UDONSHARP
             if (UdonSharpGUI.DrawDefaultUdonSharpBehaviourHeader(target)) return;
+#endif
             DrawLogo();
             ShurikenHeaderCentered(GetVersion());
             EditorGUILayout.Space();
@@ -520,8 +529,9 @@ namespace VRSL.EditorScripts
 
         public override void OnInspectorGUI()
         {
-            
+#if UDONSHARP
             if (UdonSharpGUI.DrawDefaultUdonSharpBehaviourHeader(target)) return;
+#endif
             DrawLogo();
             ShurikenHeaderCentered(GetVersion());
             EditorGUILayout.Space();
@@ -622,6 +632,7 @@ namespace VRSL.EditorScripts
             {  
                 foreach(GameObject obj in objs)
                 {
+#if UDONSHARP
                     #pragma warning disable 0618 //suppressing obsoletion warnings
                     //VRStageLighting_RAW_Static[] staticLights = obj.GetUdonSharpComponentsInChildren<VRStageLighting_RAW_Static>();
                     VRStageLighting_AudioLink_Static[] audioLinkLights = obj.GetUdonSharpComponentsInChildren<VRStageLighting_AudioLink_Static>();
@@ -632,6 +643,12 @@ namespace VRSL.EditorScripts
                 // VRStageLighting_DMX_Static[] dmxLights = obj.GetUdonSharpComponentsInChildren<VRStageLighting_DMX_Static>();
                     VRSL_LocalUIControlPanel[] controlPanels = obj.GetUdonSharpComponentsInChildren<VRSL_LocalUIControlPanel>();
                     #pragma warning restore 0618 //suppressing obsoletion warnings
+#else
+                    VRStageLighting_AudioLink_Static[] audioLinkLights = obj.GetComponentsInChildren<VRStageLighting_AudioLink_Static>();
+                    VRStageLighting_DMX_Static[] dmxLights = obj.GetComponentsInChildren<VRStageLighting_DMX_Static>();
+                    VRStageLighting_AudioLink_Laser[] audioLinkLasers = obj.GetComponentsInChildren<VRStageLighting_AudioLink_Laser>();
+                    VRSL_LocalUIControlPanel[] controlPanels = obj.GetComponentsInChildren<VRSL_LocalUIControlPanel>();
+#endif
                     if(dmxLights != null)
                     {
                         foreach(VRStageLighting_DMX_Static fixture in dmxLights)

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/FieldChangeCallbackAttribute.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/FieldChangeCallbackAttribute.cs
@@ -1,0 +1,21 @@
+#if !UDONSHARP
+
+using System;
+
+namespace VRSL
+{
+    internal class FieldChangeCallbackAttribute : Attribute
+    {
+        public FieldChangeCallbackAttribute(string v)
+        {
+            V = v;
+        }
+
+        public string V { get; }
+    }
+}
+#else
+namespace VRSL
+{
+}
+#endif

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/FieldChangeCallbackAttribute.cs.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/FieldChangeCallbackAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c31e0bac2c2c5cec8def9693974a630
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/SmoothingPanelOpener.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/SmoothingPanelOpener.cs
@@ -1,12 +1,15 @@
-﻿
+﻿using UnityEngine;
+#if UDONSHARP
 using UdonSharp;
-using UnityEngine;
 using VRC.SDKBase;
 using VRC.Udon;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
 
 public class SmoothingPanelOpener : UdonSharpBehaviour
+#else
+public class SmoothingPanelOpener : MonoBehaviour
+#endif
 {
     public Animator animator;
     public bool isOpen;
@@ -27,7 +30,11 @@ public class SmoothingPanelOpener : UdonSharpBehaviour
         animator.SetBool("isOpen", false);
     }
 
+#if UDONSHARP
     public override void Interact()
+#else
+    public void Interact()
+#endif
     {
         isOpen = !isOpen;
         if(isOpen)

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/TargetFollower.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/TargetFollower.cs
@@ -1,19 +1,28 @@
 ﻿
-using UdonSharp;
 using UnityEngine;
+#if UDONSHARP
+using UdonSharp;
 using VRC.SDKBase;
 using VRC.Udon;
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
 using UdonSharpEditor;
 #endif
+
+#endif
+
 namespace VRSL
 {
+#if UDONSHARP
     public class TargetFollower : UdonSharpBehaviour
+#else
+    public class TargetFollower : MonoBehaviour
+#endif
     {
         [Tooltip ("Enable this to follow whoever owns this object. Change the owner of this object to change who this object follows.")]
         public bool followOwner;
 
+#if UDONSHARP
         void Update() 
         {
             if(Networking.GetOwner(this.gameObject) != null && followOwner)
@@ -21,12 +30,16 @@ namespace VRSL
                 this.transform.position = Networking.GetOwner(this.gameObject).GetPosition();
             }
         }
+#endif
+
         #if !COMPILER_UDONSHARP && UNITY_EDITOR
             private void OnDrawGizmos()
             {
+#if UDONSHARP
                 #pragma warning disable 0618 //suppressing obsoletion warnings
                 this.UpdateProxy(ProxySerializationPolicy.RootOnly);
                 #pragma warning restore 0618 //suppressing obsoletion warnings
+#endif
                 Gizmos.color = Color.white;
                 Gizmos.DrawWireSphere(transform.position, 0.25f);
             }

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_AudioLink_SmoothingPanel.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_AudioLink_SmoothingPanel.cs
@@ -1,14 +1,17 @@
-﻿
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
+﻿using UnityEngine;
 using UnityEngine.UI;
-using VRC.Udon;
 
+#if UDONSHARP
+using UdonSharp;
+using VRC.SDKBase;
+using VRC.Udon;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
 
 public class VRSL_AudioLink_SmoothingPanel : UdonSharpBehaviour
+#else
+public class VRSL_AudioLink_SmoothingPanel : MonoBehaviour
+#endif
 {
     public Material smoothingMaterial;
     public Slider bassSmoothingSlider, lowerMidSmoothingSlider, upperMidSmoothingSlider, trebleSmoothingSlider, colorChordSmoothingSlider;

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_CameraConfigurator.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_CameraConfigurator.cs
@@ -1,21 +1,28 @@
-﻿
+﻿using UnityEngine;
+#if UDONSHARP
 using UdonSharp;
-using UnityEngine;
 using VRC.SDKBase;
 using VRC.Udon;
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
-using UnityEditor;
 using UdonSharpEditor;
 #endif
 
+#endif
 
+#if !COMPILER_UDONSHARP && UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace VRSL.EditorScripts
 {
+#if UDONSHARP
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
 
     public class VRSL_CameraConfigurator : UdonSharpBehaviour
+#else
+    public class VRSL_CameraConfigurator : MonoBehaviour
+#endif
     {
         public Camera camObj;
         public float defaultSize = 9.6f;
@@ -217,7 +224,9 @@ namespace VRSL.EditorScripts
         }
         public override void OnInspectorGUI()
         {
+#if UDONSHARP
             if (UdonSharpGUI.DrawDefaultUdonSharpBehaviourHeader(target)) return;
+#endif
             serializedObject.Update();
 
             

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_DMXGlobalExport.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_DMXGlobalExport.cs
@@ -1,12 +1,15 @@
-﻿
+﻿using UnityEngine;
+#if UDONSHARP
 using UdonSharp;
-using UnityEngine;
 using VRC.SDKBase;
 using VRC.Udon;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
 
 public class VRSL_DMXGlobalExport : UdonSharpBehaviour
+#else
+public class VRSL_DMXGlobalExport : MonoBehaviour
+#endif
 {
     public CustomRenderTexture dmxExportTexture;
     void Start()

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_LocalUIControlPanel.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_LocalUIControlPanel.cs
@@ -1,12 +1,18 @@
-﻿
+﻿using UnityEngine;
+#if UDONSHARP
 using UdonSharp;
-using UnityEngine;
 using VRC.SDKBase;
 using VRC.Udon;
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
-using UnityEditor;
 using UdonSharpEditor;
+#endif
+
+#endif
+
+
+#if !COMPILER_UDONSHARP && UNITY_EDITOR
+using UnityEditor;
 using System.Collections.Immutable;
 using System.Collections.Generic;
 using System;
@@ -33,11 +39,12 @@ namespace VRSL
         Low
     }
 
+#if UDONSHARP
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
-
-
-
     public class VRSL_LocalUIControlPanel : UdonSharpBehaviour
+#else
+    public class VRSL_LocalUIControlPanel : MonoBehaviour
+#endif
     {
         [SerializeField, HideInInspector]
         private VRStageLighting_AudioLink_Laser[] audioLinkLasers;
@@ -1399,7 +1406,9 @@ namespace VRSL
         }
         public override void OnInspectorGUI()
         {
+#if UDONSHARP
             if (UdonSharpGUI.DrawDefaultUdonSharpBehaviourHeader(target)) return;
+#endif
 
             EditorGUI.BeginChangeCheck();
             serializedObject.Update();

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_AudioLink_Laser.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_AudioLink_Laser.cs
@@ -1,22 +1,32 @@
-﻿
+﻿using UnityEngine;
+//using UnityEngine.UI;
+#if UDONSHARP
 using UdonSharp;
-using UnityEngine;
 using VRC.SDKBase;
 using VRC.Udon;
-//using UnityEngine.UI;
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
-using UnityEditor;
 using UdonSharpEditor;
 //using VRC.Udon;
 using VRC.Udon.Common;
 using VRC.Udon.Common.Interfaces;
+#endif
+
+#endif
+
+#if !COMPILER_UDONSHARP && UNITY_EDITOR
+using UnityEditor;
 using System.Collections.Immutable;
 #endif
+
 namespace VRSL
 {
+#if UDONSHARP
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class VRStageLighting_AudioLink_Laser : UdonSharpBehaviour
+#else
+    public class VRStageLighting_AudioLink_Laser : MonoBehaviour
+#endif
     {
 
         //////////////////Public Variables////////////////////

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_AudioLink_Static.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_AudioLink_Static.cs
@@ -1,18 +1,24 @@
 ﻿
-
-using UdonSharp;
 using UnityEngine;
+#if UDONSHARP
+using UdonSharp;
 using VRC.SDKBase;
 using VRC.Udon;
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
-using UnityEditor;
 using UdonSharpEditor;
 //using VRC.Udon;
 using VRC.Udon.Common;
 using VRC.Udon.Common.Interfaces;
+#endif
+
+#endif
+
+#if !COMPILER_UDONSHARP && UNITY_EDITOR
+using UnityEditor;
 using System.Collections.Immutable;
 #endif
+
 namespace VRSL
 {
 
@@ -24,8 +30,12 @@ namespace VRSL
         Treble
     }
 
+#if UDONSHARP
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class VRStageLighting_AudioLink_Static : UdonSharpBehaviour
+#else
+    public class VRStageLighting_AudioLink_Static : MonoBehaviour
+#endif
     {
         //////////////////Public Variables////////////////////
 
@@ -935,9 +945,11 @@ namespace VRSL
 
             private void OnDrawGizmos()
             {
+                #if UDONSHARP
                 #pragma warning disable 0618 //suppressing obsoletion warnings
                 this.UpdateProxy(ProxySerializationPolicy.RootOnly);
                 #pragma warning restore 0618 //suppressing obsoletion warnings
+                #endif
                 Gizmos.color = lightColorTint;
                 if(targetToFollow != null)
                 {

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_DMX_Static.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_DMX_Static.cs
@@ -1,25 +1,34 @@
 ﻿
-using UdonSharp;
 using UnityEngine;
+using System.Numerics;
+//using UnityEngine.UI;
+#if UDONSHARP
+using UdonSharp;
 using VRC.SDKBase;
 using VRC.Udon;
-using System.Numerics;
-
-//using UnityEngine.UI;
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
-using UnityEditor;
 using UdonSharpEditor;
 //using VRC.Udon;
 using VRC.Udon.Common;
 using VRC.Udon.Common.Interfaces;
+#endif
+
+#endif
+
+#if !COMPILER_UDONSHARP && UNITY_EDITOR
+using UnityEditor;
 using System.Collections.Immutable;
 #endif
 
 namespace VRSL
 {
+#if UDONSHARP
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class VRStageLighting_DMX_Static : UdonSharpBehaviour
+#else
+    public class VRStageLighting_DMX_Static : MonoBehaviour
+#endif
     {
         //////////////////Public Variables////////////////////
         [Header("DMX Settings")]


### PR DESCRIPTION
Allows for most of the VRSL to run in Unity standalone without fully relying on UdonSharp