### PR TITLE
URP Shader Support

### DIFF
--- a/Packages/com.acchosen.vr-stage-lighting/Editor/VRSLPipelineDetector.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Editor/VRSLPipelineDetector.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using UnityEditor;
+using System.Linq;
+using UnityEngine.Rendering;
+
+[InitializeOnLoad]
+public static class VRSLPipelineDetector
+{
+    static VRSLPipelineDetector()
+    {
+        DetectPackages();
+#if UNITY_2021_1_OR_NEWER
+        RenderPipelineManager.activeRenderPipelineTypeChanged -= DetectPackages;
+        RenderPipelineManager.activeRenderPipelineTypeChanged += DetectPackages;
+#endif
+    }
+
+    // [MenuItem("Tools/VRSL/Check Pipeline")]
+    private static void DetectPackages()
+    {
+        // Check for URP
+        bool hasURP = DoesPackageExist("com.unity.render-pipelines.universal");
+        if (hasURP) Shader.EnableKeyword("UNIVERSAL_RENDER_PIPELINE");
+        else Shader.DisableKeyword("UNIVERSAL_RENDER_PIPELINE");
+
+        // Check for other packages as needed
+        // bool hasHDRP = DoesPackageExist("com.unity.render-pipelines.");
+        bool hasHDRP = DoesPackageExist("com.unity.render-pipelines.high-definition");
+        if (hasHDRP) Shader.EnableKeyword("HIGH_DEFINITION_RENDER_PIPELINE");
+        else Shader.DisableKeyword("HIGH_DEFINITION_RENDER_PIPELINE");
+    }
+
+    private static bool DoesPackageExist(string packageName)
+    {
+        // For Unity 2019.3+
+#if UNITY_2019_3_OR_NEWER
+        var listRequest = UnityEditor.PackageManager.Client.List(true);
+        while (!listRequest.IsCompleted) { }
+
+        bool found;
+        if (listRequest.Status == UnityEditor.PackageManager.StatusCode.Success)
+        {
+            return listRequest.Result.Any(package => package.name == packageName);
+        }
+#endif
+
+        // Fallback method for earlier Unity versions: check for package directory
+        string packagePath = $"Packages/{packageName}";
+        return System.IO.Directory.Exists(packagePath);
+    }
+}

--- a/Packages/com.acchosen.vr-stage-lighting/Editor/VRSLPipelineDetector.cs.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Editor/VRSLPipelineDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b52d7f06ec680e04f912b1791a60d6d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Editor/VRSLStandardInspector.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Editor/VRSLStandardInspector.cs
@@ -1,0 +1,94 @@
+using UnityEngine;
+using UnityEditor;
+using System;
+using System.Reflection;
+using UnityEngine.Rendering;
+
+namespace VRSL.Shaders
+{
+// Create a custom shader GUI that switches between Standard and URP Lit inspector
+    public class VRSLStandardInspector : ShaderGUI
+    {
+        // References to keep track of our reflected editor instances
+        private ShaderGUI urpLitGUI = null;
+        private ShaderGUI standardGUI = null;
+        private bool guiCheckComplete;
+
+        private void EnsureShaderGUIAvailable()
+        {
+            if (guiCheckComplete) return;
+            guiCheckComplete = true;
+            // Check if the project is using URP
+            bool isURP = GraphicsSettings.currentRenderPipeline != null &&
+                         GraphicsSettings.currentRenderPipeline.GetType().ToString().Contains("Universal");
+
+            if (isURP)
+            {
+                if (urpLitGUI != null) return;
+                // Try to create URP Lit GUI instance via reflection
+                try
+                {
+                    // Get the URP Editor assembly
+                    Assembly urpEditorAssembly = null;
+                    Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+                    foreach (var assembly in assemblies)
+                    {
+                        if (assembly.GetName().Name == "Unity.RenderPipelines.Universal.Editor")
+                        {
+                            urpEditorAssembly = assembly;
+                            break;
+                        }
+                    }
+
+                    if (urpEditorAssembly != null)
+                    {
+                        // Get the LitShaderGUI type
+                        Type litGUIType = urpEditorAssembly.GetType("UnityEditor.Rendering.Universal.ShaderGUI.LitShader");
+                        if (litGUIType != null) urpLitGUI = Activator.CreateInstance(litGUIType) as ShaderGUI;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Failed to create URP Lit GUI: " + e.Message);
+                }
+            }
+            else
+            {
+                try
+                {
+                    // Get the Standard ShaderGUI type from UnityEditor assembly
+                    Assembly editorAssembly = typeof(EditorGUILayout).Assembly;
+                    Type standardGUIType = editorAssembly.GetType("UnityEditor.StandardShaderGUI");
+                    if (standardGUIType != null) standardGUI = Activator.CreateInstance(standardGUIType) as ShaderGUI;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Failed to create Standard GUI: " + e.Message);
+                }
+            }
+        }
+
+        // material changed check
+        public override void ValidateMaterial(Material material)
+        {
+            EnsureShaderGUIAvailable();
+            urpLitGUI?.ValidateMaterial(material);
+            standardGUI?.ValidateMaterial(material);
+        }
+
+        // shader change check
+        public override void AssignNewShaderToMaterial(Material material, Shader oldShader, Shader newShader)
+        {
+            EnsureShaderGUIAvailable();
+            urpLitGUI?.AssignNewShaderToMaterial(material, oldShader, newShader);
+            standardGUI?.AssignNewShaderToMaterial(material, oldShader, newShader);
+        }
+
+        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] properties)
+        {
+            EnsureShaderGUIAvailable();
+            urpLitGUI?.OnGUI(materialEditor, properties);
+            standardGUI?.OnGUI(materialEditor, properties);
+        }
+    }
+}

--- a/Packages/com.acchosen.vr-stage-lighting/Editor/VRSLStandardInspector.cs.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Editor/VRSLStandardInspector.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 807d50b54be640a3bc0f5d89db295959
+timeCreated: 1747362724

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bd468cbacf8a56e41b6da6331ad6428a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_ControllerBody.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_ControllerBody.mat
@@ -1,0 +1,124 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: mat_ControllerBody
+  m_Shader: {fileID: 4800000, guid: a088df73d2bf4e65a70b455b0cd7d95f, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _UVSec: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.20784314, g: 0.20784314, b: 0.20784314, a: 1}
+    - _Color: {r: 0.2078431, g: 0.2078431, b: 0.2078431, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_ControllerBody.mat.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_ControllerBody.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1112f2b99382bda47a7a749b3f529e41
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_ControllerHandle.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_ControllerHandle.mat
@@ -1,0 +1,125 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 32
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: mat_ControllerHandle
+  m_Shader: {fileID: 4800000, guid: a088df73d2bf4e65a70b455b0cd7d95f, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _RECEIVE_SHADOWS_OFF
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _QueueOffset: 0
+    - _ReceiveShadows: 0
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _UVSec: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.69411767, g: 1, b: 0.7176471, a: 1}
+    - _Color: {r: 0.69411767, g: 1, b: 0.7176471, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_ControllerHandle.mat.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_ControllerHandle.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85c38d875606b5c4596af0ee1fe5de10
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_SpectrumCoords.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_SpectrumCoords.mat
@@ -1,0 +1,125 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: mat_SpectrumCoords
+  m_Shader: {fileID: 4800000, guid: a088df73d2bf4e65a70b455b0cd7d95f, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _EMISSION
+  m_InvalidKeywords: []
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.178
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 3
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _UVSec: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_SpectrumCoords.mat.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_SpectrumCoords.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 21bf07ed7d39cd44096d5cc83d470eb7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_UdonAudioLink.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_UdonAudioLink.mat
@@ -1,0 +1,126 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: mat_UdonAudioLink
+  m_Shader: {fileID: 4800000, guid: a088df73d2bf4e65a70b455b0cd7d95f, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _ALPHATEST_ON
+  - _EMISSION
+  m_InvalidKeywords: []
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2450
+  stringTagMap:
+    RenderType: TransparentCutout
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 2800000, guid: 3659d46bbc594a648be926fae3b4ef45, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 3659d46bbc594a648be926fae3b4ef45, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 1
+    - _AlphaToMask: 1
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 1
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _UVSec: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_UdonAudioLink.mat.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/AudioLInkController/mat_UdonAudioLink.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c45b5c51ac25b1f42a5ab163c9bd7c43
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/InvertedCube.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/InvertedCube.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: InvertedCube
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: a088df73d2bf4e65a70b455b0cd7d95f, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-CopyScreenMaterial.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-CopyScreenMaterial.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: VRSL-CopyScreenMaterial
-  m_Shader: {fileID: 10752, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: 45aad9e069994b50955a2b176f4dd0ae, type: 3}
   m_ShaderKeywords: _GLOSSYREFLECTIONS_OFF _SPECULARHIGHLIGHTS_OFF
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-GridReader-H.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-GridReader-H.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: VRSL-DMX-GridReader-H
-  m_Shader: {fileID: 10752, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: 45aad9e069994b50955a2b176f4dd0ae, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-GridReader-V.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-GridReader-V.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: VRSL-DMX-GridReader-V
-  m_Shader: {fileID: 10752, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: 45aad9e069994b50955a2b176f4dd0ae, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-TextureReader-H.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-TextureReader-H.mat
@@ -1,0 +1,135 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-2415693450939378807
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: VRSL-DMX-TextureReader-H
+  m_Shader: {fileID: 4800000, guid: 45aad9e069994b50955a2b176f4dd0ae, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-TextureReader-H.mat.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-TextureReader-H.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d36cb61b524c94458012b0aa641a187
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-TextureReader-V.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-TextureReader-V.mat
@@ -1,0 +1,135 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-2415693450939378807
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: VRSL-DMX-TextureReader-V
+  m_Shader: {fileID: 4800000, guid: 45aad9e069994b50955a2b176f4dd0ae, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-TextureReader-V.mat.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-DMX-TextureReader-V.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1c2342b93545bc4db96a0303f85afcc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-MirrorBallStandard.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Materials/Other/VRSL-MirrorBallStandard.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: VRSL-MirrorBallStandard
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: a088df73d2bf4e65a70b455b0cd7d95f, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Other/OtherMeshes/ExampleTrussMat.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Other/OtherMeshes/ExampleTrussMat.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ExampleTrussMat
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: a088df73d2bf4e65a70b455b0cd7d95f, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Other/OtherMeshes/Materials/InvertedCube-v2.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Other/OtherMeshes/Materials/InvertedCube-v2.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: InvertedCube-v2
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: a088df73d2bf4e65a70b455b0cd7d95f, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Other/OtherMeshes/Materials/InvertedCube.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Other/OtherMeshes/Materials/InvertedCube.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: InvertedCube
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: a088df73d2bf4e65a70b455b0cd7d95f, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Other/VRSL-DemoVideoScreen.mat
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Other/VRSL-DemoVideoScreen.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: VRSL-DemoVideoScreen
-  m_Shader: {fileID: 10752, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: 45aad9e069994b50955a2b176f4dd0ae, type: 3}
   m_ShaderKeywords: _FORWARD_Y
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/AudioLink/VRSL-AudioLinkControllerWithSmoothing/AudioLinkController-WithVRSLSmoothing.prefab
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/AudioLink/VRSL-AudioLinkControllerWithSmoothing/AudioLinkController-WithVRSLSmoothing.prefab
@@ -4532,6 +4532,11 @@ PrefabInstance:
       propertyPath: serializedPublicVariablesBytesString
       value: Ai8AAAAAATIAAABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlAFQAYQBiAGwAZQAsACAAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4AAAAAAAYBAAAAAAAAACcBBAAAAHQAeQBwAGUAAWgAAABTAHkAcwB0AGUAbQAuAEMAbwBsAGwAZQBjAHQAaQBvAG4AcwAuAEcAZQBuAGUAcgBpAGMALgBMAGkAcwB0AGAAMQBbAFsAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4ALgBJAG4AdABlAHIAZgBhAGMAZQBzAC4ASQBVAGQAbwBuAFYAYQByAGkAYQBiAGwAZQAsACAAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4AXQBdACwAIABtAHMAYwBvAHIAbABpAGIAAQEJAAAAVgBhAHIAaQBhAGIAbABlAHMALwEAAAABaAAAAFMAeQBzAHQAZQBtAC4AQwBvAGwAbABlAGMAdABpAG8AbgBzAC4ARwBlAG4AZQByAGkAYwAuAEwAaQBzAHQAYAAxAFsAWwBWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAEkAbgB0AGUAcgBmAGEAYwBlAHMALgBJAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlACwAIABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgBdAF0ALAAgAG0AcwBjAG8AcgBsAGkAYgABAAAABgAAAAAAAAAABwUHBQ==
       objectReference: {fileID: 0}
+    - target: {fileID: 1790513635689481920, guid: 385ac04e8d2b6f84ea93cb8392fad970,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1112f2b99382bda47a7a749b3f529e41, type: 2}
     - target: {fileID: 2026054243217581530, guid: 385ac04e8d2b6f84ea93cb8392fad970,
         type: 3}
       propertyPath: serializedPublicVariablesBytesString
@@ -4568,6 +4573,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2533733442655874296, guid: 385ac04e8d2b6f84ea93cb8392fad970,
         type: 3}
+    - target: {fileID: 2652899046485929150, guid: 385ac04e8d2b6f84ea93cb8392fad970,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c45b5c51ac25b1f42a5ab163c9bd7c43, type: 2}
     - target: {fileID: 2699528454479361931, guid: 385ac04e8d2b6f84ea93cb8392fad970,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -4593,6 +4603,11 @@ PrefabInstance:
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2810960592333797863, guid: 385ac04e8d2b6f84ea93cb8392fad970,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1112f2b99382bda47a7a749b3f529e41, type: 2}
     - target: {fileID: 3354382617194352636, guid: 385ac04e8d2b6f84ea93cb8392fad970,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -4681,6 +4696,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 4500131507809752782, guid: 385ac04e8d2b6f84ea93cb8392fad970,
         type: 3}
+    - target: {fileID: 4740651972526149330, guid: 385ac04e8d2b6f84ea93cb8392fad970,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 85c38d875606b5c4596af0ee1fe5de10, type: 2}
     - target: {fileID: 5081559837787651755, guid: 385ac04e8d2b6f84ea93cb8392fad970,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -4812,6 +4832,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 7770076020770436658, guid: 385ac04e8d2b6f84ea93cb8392fad970,
         type: 3}
+    - target: {fileID: 7811317972803931065, guid: 385ac04e8d2b6f84ea93cb8392fad970,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1112f2b99382bda47a7a749b3f529e41, type: 2}
     - target: {fileID: 8031542696960571408, guid: 385ac04e8d2b6f84ea93cb8392fad970,
         type: 3}
       propertyPath: serializationData.Prefab

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/DMX/VRSL-DMXTextureReader-Horizontal.prefab
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/DMX/VRSL-DMXTextureReader-Horizontal.prefab
@@ -1,0 +1,295 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2833466776730655426
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7404167538915123895}
+  - component: {fileID: 8835295238122550126}
+  - component: {fileID: 5244059956826812682}
+  - component: {fileID: 846519093221050235}
+  m_Layer: 2
+  m_Name: DMX-Screen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7404167538915123895
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2833466776730655426}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0.02, y: 0.25, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1423002764036496533}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!33 &8835295238122550126
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2833466776730655426}
+  m_Mesh: {fileID: 4300000, guid: 9f8be1496465197429720247abc0c591, type: 3}
+--- !u!23 &5244059956826812682
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2833466776730655426}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 0d36cb61b524c94458012b0aa641a187, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &846519093221050235
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2833466776730655426}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &4063291549635659379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3826516087438526937}
+  - component: {fileID: 3665982595723834702}
+  - component: {fileID: 268350472267335546}
+  - component: {fileID: 2153785825024333436}
+  m_Layer: 0
+  m_Name: DMX-Cam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3826516087438526937
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4063291549635659379}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0.02, y: -3.79, z: -6.81}
+  m_LocalScale: {x: 0.5208334, y: 0.9259258, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1423002764036496533}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
+--- !u!20 &3665982595723834702
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4063291549635659379}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 11.6
+  field of view: 60
+  orthographic: 1
+  orthographic size: 9.6
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 8400000, guid: 87c3021d20ea2004cad2ca0d2dd14d07, type: 2}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &268350472267335546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4063291549635659379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 0
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 1
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!114 &2153785825024333436
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4063291549635659379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ffdb06517a284b14bb28ced573c9e07e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  camObj: {fileID: 3665982595723834702}
+  defaultSize: 9.6
+  vertDefaultSize: 5.4
+  percentageReduction: 0.6667
+  percentageFurtherReduction: 0.4444
+  yPos: -3.79
+  xPos: 0.02
+  isHorizontal: 1
+  resolution: 0
+  scaleDefine: 0
+--- !u!1 &7513435343503149002
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1423002764036496533}
+  m_Layer: 0
+  m_Name: VRSL-DMXTextureReader-Horizontal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1423002764036496533
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7513435343503149002}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: -1000, z: 0}
+  m_LocalScale: {x: 1.92, y: 1.08, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3826516087438526937}
+  - {fileID: 7404167538915123895}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/DMX/VRSL-DMXTextureReader-Horizontal.prefab.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/DMX/VRSL-DMXTextureReader-Horizontal.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de7d866d33de1e045af7754bc2f380a6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/DMX/VRSL-DMXTextureReader-Vertical.prefab
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/DMX/VRSL-DMXTextureReader-Vertical.prefab
@@ -1,0 +1,295 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1415385737827519026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5440327931230866317}
+  - component: {fileID: 6493075589998810163}
+  - component: {fileID: 6738256882280258161}
+  - component: {fileID: 4273284189286750210}
+  m_Layer: 2
+  m_Name: DMX-Screen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5440327931230866317
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1415385737827519026}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0.02, y: 0.25, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5829150019264881103}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!33 &6493075589998810163
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1415385737827519026}
+  m_Mesh: {fileID: 4300000, guid: 9f8be1496465197429720247abc0c591, type: 3}
+--- !u!23 &6738256882280258161
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1415385737827519026}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d1c2342b93545bc4db96a0303f85afcc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &4273284189286750210
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1415385737827519026}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &6366782054369551332
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5829150019264881103}
+  m_Layer: 0
+  m_Name: VRSL-DMXTextureReader-Vertical
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5829150019264881103
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6366782054369551332}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: -1000, z: 0}
+  m_LocalScale: {x: 1.92, y: 1.08, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 783285033697522139}
+  - {fileID: 5440327931230866317}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
+--- !u!1 &8228976269499922352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 783285033697522139}
+  - component: {fileID: 7251283436656018446}
+  - component: {fileID: 2549235371805715662}
+  - component: {fileID: 1783722776746690376}
+  m_Layer: 0
+  m_Name: DMX-Cam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &783285033697522139
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8228976269499922352}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.478, y: 0.25, z: -6.81}
+  m_LocalScale: {x: 0.5208334, y: 0.9259258, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5829150019264881103}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &7251283436656018446
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8228976269499922352}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 11.6
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5.4
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 8400000, guid: 87c3021d20ea2004cad2ca0d2dd14d07, type: 2}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &2549235371805715662
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8228976269499922352}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 0
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 1
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!114 &1783722776746690376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8228976269499922352}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ffdb06517a284b14bb28ced573c9e07e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  camObj: {fileID: 7251283436656018446}
+  defaultSize: 9.6
+  vertDefaultSize: 5.4
+  percentageReduction: 0.6667
+  percentageFurtherReduction: 0.4444
+  yPos: 0.25
+  xPos: 4.478
+  isHorizontal: 0
+  resolution: 0
+  scaleDefine: 0

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/DMX/VRSL-DMXTextureReader-Vertical.prefab.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Prefabs/DMX/VRSL-DMXTextureReader-Vertical.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1c25784e40554f94ba69632302e66161
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Discoball/VRSL-AudioLink-Discoball.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Discoball/VRSL-AudioLink-Discoball.shader
@@ -1,5 +1,5 @@
 ﻿Shader "VRSL/AudioLink/Other/Discoball"
- {
+{
      Properties
      {
          [Header(Audio Section)]
@@ -36,6 +36,174 @@
         _ClippingThreshold ("Clipping Threshold", Range (0,1)) = 0.5
         _GlobalIntensityBlend("Global Intensity Blend", Range(0,1)) = 1
 
+     }
+     SubShader
+     {
+         Tags
+         {
+             "Queue" = "Transparent+1"
+             "ForceNoShadowCasting"="True"
+             "IgnoreProjector"="True"
+             "RenderType" = "Transparent"
+             "RenderingPipeline" = "UniversalPipeline"
+         }
+         Offset -1, -5
+         Stencil
+         {
+             Ref 142
+             Comp NotEqual
+             Pass Keep
+         }
+
+         Pass
+         {
+             AlphaToMask [_AlphaToCoverage]
+             Cull Front
+             Ztest Greater
+             ZWrite Off
+             Blend DstColor [_BlendDst]
+             Lighting Off
+             SeparateSpecular Off
+             CGPROGRAM
+             #pragma vertex vert
+             #pragma fragment frag
+             uniform samplerCUBE _Cube;
+             #define VRSL_AUDIOLINK
+             #pragma multi_compile_local _ _ALPHATEST_ON
+             float4 _Cube_ST;
+             float _RotationSpeed;
+             #include "UnityCG.cginc"
+
+             struct appdata
+             {
+                 float4 vertex : POSITION;
+                 float2 uv : TEXCOORD0;
+                 float3 texcoord : TEXCOORD1;
+             };
+
+             struct v2f
+             {
+                 float4 vertex : SV_POSITION;
+                 float2 uv : TEXCOORD0;
+                 float3 ray : TEXCOORD2;
+                 float4 screenPos : TEXCOORD4;
+                 float4 worldDirection : TEXCOORD5;
+                 float4 worldPos : TEXCOORD6;
+                 float4 outColor : TEXCOORD7;
+                 UNITY_VERTEX_OUTPUT_STEREO
+             };
+
+             #include "../../Shared/VRSL-Defines.cginc"
+             half _Multiplier;
+             #include "../Shared/VRSL-AudioLink-Functions.cginc"
+
+             float4 Rotation(float4 vertPos)
+             {
+                 //CALCULATE BASE ROTATION. MORE FUN MATH. THIS IS FOR PAN.
+                 float angleY = radians(_Time.y * _RotationSpeed);
+                 float c = cos(angleY);
+                 float s = sin(angleY);
+                 float4x4 rotateYMatrix = float4x4(
+                     c, 0, s, 0,
+                     0, 1, 0, 0,
+                     -s, 0, c, 0,
+                     0, 0, 0, 1
+                 );
+                 return mul(rotateYMatrix, vertPos);
+             }
+
+             inline float4 CalculateFrustumCorrection()
+             {
+                 float x1 = -UNITY_MATRIX_P._31 / (UNITY_MATRIX_P._11 * UNITY_MATRIX_P._34);
+                 float x2 = -UNITY_MATRIX_P._32 / (UNITY_MATRIX_P._22 * UNITY_MATRIX_P._34);
+                 return float4(
+                     x1, x2, 0,
+                     UNITY_MATRIX_P._33 / UNITY_MATRIX_P._34 + x1 * UNITY_MATRIX_P._13 + x2 * UNITY_MATRIX_P._23);
+             }
+
+             //CREDIT TO DJ LUKIS FOR MIRROR DEPTH CORRECTION
+             inline float CorrectedLinearEyeDepth(float z, float B)
+             {
+                 return 1.0 / (z / UNITY_MATRIX_P._34 + B);
+             }
+
+             v2f vert(appdata v)
+             {
+                 v2f o;
+                 UNITY_INITIALIZE_OUTPUT(v2f, o); //DON'T INITIALIZE OR IT WILL BREAK PROJECTION
+                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                 //UNITY_TRANSFER_INSTANCE_ID(v, o);
+
+                 o.vertex = UnityObjectToClipPos(v.vertex);
+                 o.ray = UnityObjectToViewPos(v.vertex).xyz;
+                 o.ray = o.ray.xyz * float3(-1, -1, 1);
+                 o.ray = lerp(o.ray, v.texcoord, v.texcoord.z != 0);
+                 o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+                 o.screenPos = ComputeScreenPos(o.vertex);
+                 o.worldDirection.xyz = o.worldPos.xyz - _WorldSpaceCameraPos;
+                 // pack correction factor into direction w component to save space
+                 o.worldDirection.w = dot(o.vertex, CalculateFrustumCorrection());
+                 o.outColor = getEmissionColor();
+                 return o;
+             }
+
+             #define IF(a, b, c) lerp(b, c, step((fixed) (a), 0));
+
+             fixed4 frag(v2f i) : SV_Target
+             {
+                 float globalintensity = getGlobalIntensity();
+                 float finalintensity = getFinalIntensity();
+
+                 if (globalintensity <= 0.05 || finalintensity <= 0.05) return half4(0, 0, 0, 0);
+
+                 #if _ALPHATEST_ON
+                    float2 pos = i.screenPos.xy / i.screenPos.w;
+                    pos *= _ScreenParams.xy;
+                    float DITHER_THRESHOLDS[16] =
+                    {
+                        1.0 / 17.0,  9.0 / 17.0,  3.0 / 17.0, 11.0 / 17.0,
+                        13.0 / 17.0,  5.0 / 17.0, 15.0 / 17.0,  7.0 / 17.0,
+                        4.0 / 17.0, 12.0 / 17.0,  2.0 / 17.0, 10.0 / 17.0,
+                        16.0 / 17.0,  8.0 / 17.0, 14.0 / 17.0,  6.0 / 17.0
+                    };
+                    int index = (int)((uint(pos.x) % 4) * 4 + uint(pos.y) % 4);
+                 #endif
+                 float4 depthdirect = i.worldDirection * (1.0f / i.vertex.w);
+                 float sceneZ = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i.screenPos.xy / i.screenPos.w);
+
+                 #if UNITY_REVERSED_Z
+                 if (sceneZ == 0) return half4(0, 0, 0, 0);
+                 #else
+                    if (sceneZ == 1) return half4(0,0,0,0);
+                 #endif
+
+                 float depth = CorrectedLinearEyeDepth(sceneZ, depthdirect.w);
+                 i.ray = i.ray * (_ProjectionParams.z / i.ray.z);
+                 depth = Linear01Depth((1.0 - (depth * _ZBufferParams.w)) / (depth * _ZBufferParams.z));
+                 float3 wpos = mul(unity_CameraToWorld, float4(i.ray * depth, 1)).xyz;
+                 float UVscale = pow(abs(distance(mul(unity_ObjectToWorld, float4(0.0, 0.0, 0.0, 1.0)).xyz, wpos)), -1);
+                 float3 projPos = (mul(unity_WorldToObject, float4(wpos, 1)));
+
+                 if (0.0 < abs(projPos.x) < 0.1) return half4(0, 0, 0, 0);
+
+                 projPos = Rotation(float4(projPos, 0)).xyz;
+                 float4 col = (texCUBE(_Cube, projPos));
+                 col = col * (i.outColor * (4 * UVscale));
+                 col = (col * _Multiplier) * GetAudioReactAmplitude();
+                 col = ((col * globalintensity) * finalintensity);
+                 col = col * _UniversalIntensity;
+                 #ifdef _ALPHATEST_ON
+                    clip(col.a - DITHER_THRESHOLDS[index]);
+                    clip((((col.r + col.g + col.b)/3) * (_ClippingThreshold)) - DITHER_THRESHOLDS[index]);
+                    return col;
+                 #else
+                 return col;
+                 #endif
+             }
+             ENDCG
+         }
+
+         // mesh is specifically transparent, ignore the depth pass stuff
      }
      SubShader
      {

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Discoball/VRSL-AudioLink-Discoball.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Discoball/VRSL-AudioLink-Discoball.shader
@@ -79,6 +79,7 @@
                  float4 vertex : POSITION;
                  float2 uv : TEXCOORD0;
                  float3 texcoord : TEXCOORD1;
+                 UNITY_VERTEX_INPUT_INSTANCE_ID
              };
 
              struct v2f
@@ -130,9 +131,9 @@
              v2f vert(appdata v)
              {
                  v2f o;
+                 UNITY_SETUP_INSTANCE_ID(v);
                  UNITY_INITIALIZE_OUTPUT(v2f, o); //DON'T INITIALIZE OR IT WILL BREAK PROJECTION
                  UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                 //UNITY_TRANSFER_INSTANCE_ID(v, o);
 
                  o.vertex = UnityObjectToClipPos(v.vertex);
                  o.ray = UnityObjectToViewPos(v.vertex).xyz;
@@ -151,6 +152,7 @@
 
              fixed4 frag(v2f i) : SV_Target
              {
+                 UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
                  float globalintensity = getGlobalIntensity();
                  float finalintensity = getFinalIntensity();
 
@@ -172,8 +174,9 @@
                  float sceneZ = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i.screenPos.xy / i.screenPos.w);
 
                  #if UNITY_REVERSED_Z
-                 if (sceneZ == 0) return half4(0, 0, 0, 0);
+                    if (sceneZ == 0) return half4(0, 0, 0, 0);
                  #else
+                    sceneZ = lerp(UNITY_NEAR_CLIP_VALUE, 1, sceneZ);
                     if (sceneZ == 1) return half4(0,0,0,0);
                  #endif
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-BasicLaser.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-BasicLaser.shader
@@ -50,6 +50,463 @@
     }
     SubShader
     {
+        Tags
+        {
+            "RenderType"="Transparent" "Queue" = "Transparent+4" "RenderingPipeline" = "UniversalPipeline"
+        }
+        Cull Off
+        Blend One One
+        Zwrite Off
+        LOD 100
+
+        Pass
+        {
+
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            // make fog work
+            #pragma multi_compile_fog
+            #pragma multi_compile_instancing
+            #define VRSL_AUDIOLINK
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float2 uv : TEXCOORD0;
+                float2 uv2 : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float2 uv2 : TEXCOORD1;
+                float3 normal : TEXCOORD2;
+                UNITY_FOG_COORDS(9)
+                float4 vertex : SV_POSITION;
+                float4 worldPos : TEXCOORD3;
+                float3 viewDir : TEXCOORD4;
+                float4 panTiltLengthWidth : TEXCOORD5; //ch 1,2,3,4
+                float4 flatnessBeamCountSpinThickness : TEXCOORD6; //ch 5,6,7,12
+                float4 rgbIntensity : TEXCOORD7; // ch 8,9,10,11
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            sampler2D _MainTex, _SamplingTexture;
+            float4 _MainTex_ST;
+            half _XConeFlatness, _ZRotation, _UniversalIntensity;
+            half _EndFade, _FadeStrength, _InternalShine, _LaserSoftening, _InternalShineLength, _Multiplier;
+            uint _EnableCompatibilityMode;
+            uniform const float compatSampleYAxis = 0.019231;
+            uniform const float standardSampleYAxis = 0.00762;
+            #include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+
+
+            UNITY_INSTANCING_BUFFER_START(Props)
+                UNITY_DEFINE_INSTANCED_PROP(float, _EnableAudioLink)
+                UNITY_DEFINE_INSTANCED_PROP(float, _EnableColorChord)
+                UNITY_DEFINE_INSTANCED_PROP(float, _NumBands)
+                UNITY_DEFINE_INSTANCED_PROP(float, _Band)
+                UNITY_DEFINE_INSTANCED_PROP(float, _BandMultiplier)
+                UNITY_DEFINE_INSTANCED_PROP(float, _Delay)
+                UNITY_DEFINE_INSTANCED_PROP(uint, _LaserCount)
+                UNITY_DEFINE_INSTANCED_PROP(uint, _EnableColorTextureSample)
+                UNITY_DEFINE_INSTANCED_PROP(float, _Scroll)
+                UNITY_DEFINE_INSTANCED_PROP(float, _XRotation)
+                UNITY_DEFINE_INSTANCED_PROP(float, _YRotation)
+                UNITY_DEFINE_INSTANCED_PROP(float, _AltZRotation)
+                UNITY_DEFINE_INSTANCED_PROP(float, _AltXRotation)
+                UNITY_DEFINE_INSTANCED_PROP(float, _AltYRotation)
+                UNITY_DEFINE_INSTANCED_PROP(float, _LaserThickness)
+                UNITY_DEFINE_INSTANCED_PROP(float4, _Emission)
+                UNITY_DEFINE_INSTANCED_PROP(float, _ZConeFlatness)
+                UNITY_DEFINE_INSTANCED_PROP(float, _ZConeFlatnessAlt)
+                UNITY_DEFINE_INSTANCED_PROP(float, _VertexConeWidth)
+                UNITY_DEFINE_INSTANCED_PROP(float, _VertexConeLength)
+                UNITY_DEFINE_INSTANCED_PROP(float, _GlobalIntensity)
+                UNITY_DEFINE_INSTANCED_PROP(float, _GlobalIntensityBlend)
+                UNITY_DEFINE_INSTANCED_PROP(float, _FinalIntensity)
+                UNITY_DEFINE_INSTANCED_PROP(float, _TextureColorSampleX)
+                UNITY_DEFINE_INSTANCED_PROP(float, _TextureColorSampleY)
+                UNITY_DEFINE_INSTANCED_PROP(float, _BlackOut)
+                UNITY_DEFINE_INSTANCED_PROP(float, _ThemeColorTarget)
+                UNITY_DEFINE_INSTANCED_PROP(uint, _EnableThemeColorSampling)
+                UNITY_DEFINE_INSTANCED_PROP(uint, _UseTraditionalSampling)
+            UNITY_INSTANCING_BUFFER_END(Props)
+
+            inline float AudioLinkLerp3_g5(int Band, float Delay)
+            {
+                return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+            }
+
+            float getNumBands()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _NumBands);
+            }
+
+            float getBand()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _Band);
+            }
+
+            float getDelay()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _Delay);
+            }
+
+            float getBandMultiplier()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _BandMultiplier);
+            }
+
+            float checkIfAudioLink()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _EnableAudioLink);
+            }
+
+            uint checkIfColorChord()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _EnableColorChord);
+            }
+
+            #define IF(a, b, c) lerp(b, c, step((fixed) (a), 0));
+
+            float getPan()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _XRotation);
+            }
+
+            float getAltPan()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _AltXRotation);
+            }
+
+            float getTilt()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _YRotation);
+            }
+
+            float getAltTilt()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _AltYRotation);
+            }
+
+            float getAltTwist()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _AltZRotation);
+            }
+
+            uint getLaserCount()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _LaserCount);
+            }
+
+            float getConeWidth()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _VertexConeWidth);
+            }
+
+            float getConeLength()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _VertexConeLength);
+            }
+
+            float getLaserThickness()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _LaserThickness);
+            }
+
+            float getScrollSpeed()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _Scroll);
+            }
+
+            float getGlobalIntensity()
+            {
+                return lerp(1.0,UNITY_ACCESS_INSTANCED_PROP(Props, _GlobalIntensity),
+                                        UNITY_ACCESS_INSTANCED_PROP(Props, _GlobalIntensityBlend));
+            }
+
+            float getFinalIntensity()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _FinalIntensity);
+            }
+
+            float getConeFlatness()
+            {
+                return clamp(
+                    UNITY_ACCESS_INSTANCED_PROP(Props, _ZConeFlatness) + UNITY_ACCESS_INSTANCED_PROP(
+                        Props, _ZConeFlatnessAlt), 0, 1.999);
+            }
+
+
+            float3 RGB2HSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            float3 hsb2rgb(float3 c)
+            {
+                float3 rgb = clamp(abs(fmod(c.x * 6.0 + float3(0.0, 4.0, 2.0), 6) - 3.0) - 1.0, 0, 1);
+                rgb = rgb * rgb * (3.0 - 2.0 * rgb);
+                return c.z * lerp(float3(1, 1, 1), rgb, c.y);
+            }
+
+            float4 GetTextureSampleColor()
+            {
+                float4 rawColor = tex2Dlod(_SamplingTexture,
+                    float4(
+                        UNITY_ACCESS_INSTANCED_PROP(Props, _TextureColorSampleX),
+                        UNITY_ACCESS_INSTANCED_PROP(Props, _TextureColorSampleY), 0, 0));
+                float3 h = (RGB2HSV(rawColor.rgb));
+                h.z = 1.0;
+                //return float4(hsb2rgb(h),1);
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _UseTraditionalSampling) > 0
+                     ? rawColor
+                     : float4(hsb2rgb(h), 1);
+            }
+
+            float GetAudioReactAmplitude()
+            {
+                if (checkIfAudioLink() > 0)
+                {
+                    return AudioLinkLerp3_g5(getBand(), getDelay()) * getBandMultiplier();
+                }
+                else
+                {
+                    return 1;
+                }
+            }
+
+            float4 GetColorChordLight()
+            {
+                return AudioLinkData(ALPASS_CCLIGHTS).rgba;
+            }
+
+            float4 GetThemeSampleColor()
+            {
+                switch (UNITY_ACCESS_INSTANCED_PROP(Props, _ThemeColorTarget))
+                {
+                case 1:
+                    return AudioLinkData(ALPASS_THEME_COLOR0);
+                case 2:
+                    return AudioLinkData(ALPASS_THEME_COLOR1);
+                case 3:
+                    return AudioLinkData(ALPASS_THEME_COLOR2);
+                case 4:
+                    return AudioLinkData(ALPASS_THEME_COLOR3);
+                default:
+                    return float4(0, 0, 0, 1);
+                }
+            }
+
+            float4 getEmissionColor()
+            {
+                float4 emissiveColor = UNITY_ACCESS_INSTANCED_PROP(Props, _Emission);
+                float4 col = UNITY_ACCESS_INSTANCED_PROP(Props, _EnableColorTextureSample) > 0
+                               ? ((emissiveColor.r + emissiveColor.g + emissiveColor.b) / 3.0) * GetTextureSampleColor()
+                               : emissiveColor;
+                col = UNITY_ACCESS_INSTANCED_PROP(Props, _EnableThemeColorSampling) > 0
+              ? ((emissiveColor.r + emissiveColor.g + emissiveColor.b) / 3.0) *
+              GetThemeSampleColor()
+              : col;
+                return checkIfColorChord() == 1 ? GetColorChordLight() : col;
+            }
+
+            float4 CalculateRotations(appdata v, float4 input, float pan, float tilt, float roll)
+            {
+                float angleY = radians(pan);
+                float c = cos(angleY);
+                float s = sin(angleY);
+                float4x4 rotateYMatrix = float4x4(c, -s, 0, 0,
+                        s, c, 0, 0,
+                        0, 0, 1, 0,
+                        0, 0, 0, 1);
+                float4 BaseAndFixturePos = input;
+                float4 localRotY = mul(rotateYMatrix, BaseAndFixturePos);
+
+
+                float angleX = radians(tilt);
+                c = cos(angleX);
+                s = sin(angleX);
+                float4x4 rotateXMatrix = float4x4(1, 0, 0, 0,
+                              0, c, -s, 0,
+                              0, s, c, 0,
+                              0, 0, 0, 1);
+
+                float4x4 rotateXYMatrix = mul(rotateYMatrix, rotateXMatrix);
+                //float4 localRotXY = mul(rotateXYMatrix, input);
+
+
+                float angleZ = radians(roll);
+                c = cos(angleZ);
+                s = sin(angleZ);
+                float4x4 rotateZMatrix = float4x4(c, 0, s, 0,
+                0, 1, 0, 0,
+                -s, 0, c, 0,
+                0, 0, 0, 1);
+                float4x4 rotateXYZMatrix = mul(rotateZMatrix, rotateXYMatrix);
+                float4 localRotXYZ = mul(rotateXYZMatrix, input);
+                input.xyz = localRotXYZ.xyz;
+                return input;
+                //LOCALROTXY IS COMBINED ROTATION
+            }
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                o.rgbIntensity.w = 1;
+                if (getGlobalIntensity() <= 0.05 || getFinalIntensity() <= 0.05 || _UniversalIntensity <= 0.05 || o.
+      rgbIntensity.w <= 0.05)
+                {
+                    o.vertex = UnityObjectToClipPos(float4(0, 0, 0, 0));
+                    return o;
+                }
+                //replacement for _WorldSpaceCameraPos
+                float3 wpos;
+                wpos.x = unity_CameraToWorld[0][3];
+                wpos.y = unity_CameraToWorld[1][3];
+                wpos.z = unity_CameraToWorld[2][3];
+
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                o.uv2 = TRANSFORM_TEX(v.uv2, _MainTex);
+
+
+                //Cone Length
+                float length = getConeLength();
+                v.vertex.y = lerp(v.vertex.y, v.vertex.y * 2, length);
+
+
+                //Cone Width
+                float width = getConeWidth();
+                float4 vert = lerp(v.vertex, float4(v.vertex.xyz + v.normal * width, 1), v.uv2.y);
+                vert.y = v.vertex.y; //Prevent the cone from elongating when changing width.
+
+                // Cone Flatness for X and Z
+                float flatness = getConeFlatness();
+                vert.z = lerp(vert.z, vert.z / 2, flatness);
+                //  vert.x = lerp(vert.x, vert.x/2, _XConeFlatness);
+                float xRot = getPan() + getAltPan();
+                float yRot = getTilt() + getAltTilt();
+                vert = CalculateRotations(v, vert, _ZRotation + getAltTwist(), xRot, yRot);
+
+                o.viewDir = normalize(wpos - mul(unity_ObjectToWorld, vert).xyz);
+                v.normal = CalculateRotations(v, float4(v.normal, 1), _ZRotation + getAltTwist(), xRot, yRot).xyz;
+                o.normal = normalize(mul(float4(v.normal, 0.0), unity_WorldToObject).xyz);
+                o.worldPos = mul(unity_ObjectToWorld, vert);
+                o.vertex = UnityObjectToClipPos(vert);
+                return o;
+            }
+
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(i);
+                i.rgbIntensity.w = GetAudioReactAmplitude();
+                if (getGlobalIntensity() <= 0.05 || getFinalIntensity() <= 0.05 || _UniversalIntensity <= 0.05 || i.
+     rgbIntensity.w <= 0.05)
+                {
+                    return half4(0, 0, 0, 0);
+                }
+                float fade = pow(saturate(dot(normalize(i.normal), i.viewDir)), _FadeStrength);
+
+
+                // fade = pow(fade, pow(_FadeStrength, _FadeAmt)) * fade;
+                // sample the texture
+                float4 actualcolor = getEmissionColor() * _Multiplier;
+                float4 color = lerp(float4(0, 0, 0, 0), actualcolor, getGlobalIntensity());
+                float3 newColor = RGB2HSV(color.rgb);
+                newColor.y -= 0.1;
+                color.rgb = hsb2rgb(newColor);
+
+                color = color * getFinalIntensity();
+                color = color * _UniversalIntensity;
+                color = color * i.rgbIntensity.w;
+                fixed4 col = float4(1, 1, 1, 1);
+                fixed4 alphaMask = tex2D(_MainTex, i.uv2);
+                float2 laserUV = i.uv2;
+                col *= color;
+
+                //Draw Beams
+                float scroll = getScrollSpeed();
+                laserUV.x = laserUV.x += _Time.y * scroll;
+                float beamcount = getLaserCount();
+                laserUV.x = frac(laserUV.x * beamcount);
+                laserUV.x = laserUV.x - 0.5;
+                float thiknes = getLaserThickness();
+
+
+                // Transparency (with gradation)
+                //float dist = normalize(distance(i.worldPos, float4(0,0,0,0))); 
+                // fade = lerp(1,fade, pow(dist, _FadeAmt));
+
+
+                float beams = (beamcount * thiknes * 0.1) / abs(laserUV.x);
+                float transv = pow((-i.uv2.y + 1), _EndFade);
+                col = col * beams;
+
+                col += pow(-laserUV.y + 1, _InternalShineLength) * 3 * _InternalShine * color;
+
+                // float beamGradCorrect = .2 / (1.-laserUV.y);
+                // col *= beamGradCorrect;
+                // Clamping here softens the depiction
+                col = clamp(0, _LaserSoftening, col);
+
+                // col = lerp(col, col*10, _ZConeFlatness/1.999);
+                // float edgeFadeL = distance(i.uv2.x, 0.75);
+                // float edgeFadeR = distance(i.uv2.x, 0.25);
+                // float4 edgee = lerp(float4(0,0,0,0), col, pow(edgeFadeR * edgeFadeL, _FadeStrength));
+                // col = lerp(col, edgee, _ZConeFlatness/1.999);
+
+                //                col.xyz += rimlight.xyz;
+                //col *= fade;
+                col = lerp(float4(0, 0, 0, 0), col, transv);
+                float pi = 3.14159;
+                float edgeMask = clamp((((sin((12.5 * i.uv2.x) + 4.75)))) / pi * 6, 0, 1);
+                edgeMask = 1 - edgeMask;
+                if (i.uv2.y > 0.99)
+                {
+                    discard;
+                    return float4(0, 0, 0, 0);
+                }
+
+                // col = col * col *;
+                // float4 flatCol = col * flatEdgeMask.r;
+                float flatness = getConeFlatness();
+
+                float4 flatCol = col * edgeMask;
+                col = lerp(flatCol, col, pow(((flatness / 2.0) - 1.0) * -1, 0.95));
+                col *= getFinalIntensity() * _UniversalIntensity * i.rgbIntensity.w;
+                col *= UNITY_ACCESS_INSTANCED_PROP(Props, _BlackOut);
+                return col;
+            }
+            ENDCG
+        }
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+    SubShader
+    {
 		Tags { "RenderType"="Transparent" "Queue" = "Transparent+4" }
 		Cull Off
 		Blend One One

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-ProjectionMesh.shader
@@ -128,6 +128,96 @@ Shader "VRSL/AudioLink/Standard Mover/Projection"
 
 
 	}
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+        }
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Cull Front
+            Ztest GEqual
+            ZWrite Off
+            Blend DstColor [_BlendDst]
+            BlendOp Add
+            Offset -1, -1
+            Lighting Off
+
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma shader_feature_local _MULTISAMPLEDEPTH
+            //#pragma multi_compile_fog
+            #pragma multi_compile_instancing
+            #pragma instancing_options assumeuniformscaling
+            //#pragma multi_compile _DNENABLER_NONE _DNENABLER_USEDNTEXTURE
+            #define PROJECTION_YES //To identify the pass in the vert/frag shaders
+            #define PROJECTION_MOVER
+            #define VRSL_AUDIOLINK
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines.cginc" //Property Defines are here
+
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float3 texcoord : TEXCOORD1;
+                float4 color : COLOR;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float4 projectionorigin : TEXCOORD2;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float4 audioGlobalFinalConeIntensity : TEXCOORD1;
+                float3 ray : TEXCOORD2;
+                float4 screenPos : TEXCOORD4;
+                float4 color : COLOR;
+                float3 normal : TEXCOORD3;
+                //float2 sector: TEXCOORD10;
+                float4 projectionorigin : TEXCOORD5;
+                float4 worldDirection : TEXCOORD6;
+                float4 worldPos : TEXCOORD7;
+                float3 viewDir : TEXCOORD8;
+                float4 emissionColor : TEXCOORD9;
+                //float3 intensityStrobeWidth : TEXCOORD9;
+                //float4 goboPlusSpinPanTilt : TEXCOORD11;
+                //float4 rgbColor : TEXCOORD12;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "../Shared/VRSL-AudioLink-Functions.cginc" //Custom Functions
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-ProjectionFrag.cginc" //Fragment Shader is here
+
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-Vertex.cginc" //Vertex Shader is here
+
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
 		SubShader
 	{
 		

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-VolumetricMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-VolumetricMesh.shader
@@ -147,6 +147,97 @@
 		//[KeywordEnum(None, UseDNTexture)] _DNEnabler ("Enable Depth Normal Texture", Float) = 0
 
 	}
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+        }
+        //Volumetric Pass
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Blend One [_BlendDst]
+            Cull Off
+            ZWrite Off
+            Lighting Off
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            //#pragma multi_compile_fog
+            #pragma multi_compile_local _ _MAGIC_NOISE_ON_HIGH
+            #pragma multi_compile_local _ _MAGIC_NOISE_ON_MED
+            #pragma multi_compile_local _ _USE_DEPTH_LIGHT
+            #pragma multi_compile_local _ _POTATO_MODE_ON
+            #pragma multi_compile_local _ _HQ_MODE
+            #pragma multi_compile_local _ _2D_NOISE_ON
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma multi_compile_instancing
+            #pragma instancing_options assumeuniformscaling
+            #define VOLUMETRIC_YES //To identify the pass in the vert/frag
+            #define VRSL_AUDIOLINK
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-AudioLink-Functions.cginc" //Custom Functions
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float4 color : COLOR;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float2 uv2 : TEXCOORD3;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                centroid float2 uv : TEXCOORD0;
+                float blindingEffect : TEXCOORD1;
+                float4 worldPos : TEXCOORD2;
+                float4 color : TEXCOORD3;
+                float3 audioGlobalFinalIntensity : TEXCOORD4;
+                float2 camAngleLen : TEXCOORD5;
+                float4 screenPos : TEXCOORD6;
+                float4 pos : SV_POSITION;
+                float3 objPos : TEXCOORD7;
+                centroid float3 objNormal : TEXCOORD8;
+                float2 stripeInfo : TEXCOORD9;
+                float2 uvClone : TEXCOORD10;
+                float3 norm : TEXCOORD11;
+                float4 emissionColor : TEXCOORD12;
+                float2 uv2 : TEXCOORD13;
+                float4 worldDirection : TEXCOORD14;
+                float coneWidth : TEXCOORD15;
+                //float3 intensityStrobeGOBOSpinSpeed : TEXCOORD15;
+                //float4 rgbColor : TEXCOORD16;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-VolumetricFrag.cginc" //Fragment Shader is here
+
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-Vertex.cginc"
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
 		SubShader
 	{
 		

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-FixtureMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-FixtureMesh.shader
@@ -110,6 +110,140 @@
 
 
 	}
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderingPipeline"="UniversalPipeline"
+        }
+
+        Pass
+        {
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_fwdbase
+            #pragma multi_compile_instancing
+            #pragma shader_feature_local _LIGHTING_MODEL
+            //REMOVE THIS WHEN FINISHED DEBUGGING
+            //#pragma target 4.5
+
+            #define GEOMETRY
+            #define FIXTURE_EMIT
+            #define VRSL_AUDIOLINK
+            #define WASH
+            #ifndef UNITY_PASS_FORWARDBASE
+            #define UNITY_PASS_FORWARDBASE
+            #endif
+            //DEBUGGING BUFFER
+            RWStructuredBuffer<float> buffer : register(u1);
+            RWStructuredBuffer<float4> buffer4 : register(u2);
+
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "AutoLight.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float4 color : COLOR;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float3 btn[3] : TEXCOORD3; //TEXCOORD2, TEXCOORD3 | bitangent, tangent, worldNormal
+                float3 worldPos : TEXCOORD6;
+                #ifdef _LIGHTING_MODEL
+			        UNITY_LIGHTING_COORDS(7,8)
+			        float4 eyeVec : TEXCOORD12;
+			        half4 ambientOrLightmapUV : TEXCOORD13;
+                #else
+                float3 objPos : TEXCOORD7;
+                float3 objNormal : TEXCOORD8;
+                SHADOW_COORDS(11)
+                #endif
+                float4 color : COLOR;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                // SHADOW_COORDS(11)
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            //#include "../Shared/VRSL-AudioLink-Defines.cginc"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-AudioLink-Functions.cginc"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-LightingFunctions.cginc"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-StandardLighting.cginc"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-Vertex.cginc"
+            ENDCG
+        }
+        //UsePass "Legacy Shaders/VertexLit/SHADOWCASTER"
+        Pass
+        {
+            Tags
+            {
+                "LightMode"="ShadowCaster"
+            }
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_shadowcaster
+            #pragma multi_compile_instancing
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #define WASH
+            #define VRSL_AUDIOLINK
+            #include "UnityCG.cginc"
+
+            struct v2f
+            {
+                V2F_SHADOW_CASTER;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata_full v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                    UNITY_INITIALIZE_OUTPUT(v2f, o); //DON'T INITIALIZE OR IT WILL BREAK PROJECTION
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                o.pos = ComputeScreenPos(UnityObjectToClipPos(v.vertex));
+                TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                #ifdef LOD_FADE_CROSSFADE
+                    float2 vpos = i.pos.xy / i.pos.w * _ScreenParams.xy;
+                    UnityApplyDitherCrossFade(vpos);
+                #endif
+
+                SHADOW_CASTER_FRAGMENT(i)
+            }
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
 		SubShader
 	{
 		

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-ProjectionMesh.shader
@@ -123,6 +123,99 @@
 
 
 	}
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+        }
+
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Cull Front
+            Ztest GEqual
+            ZWrite Off
+            Blend DstColor [_BlendDst]
+            BlendOp Add
+            Offset -1, -1
+            Lighting Off
+
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma shader_feature_local _MULTISAMPLEDEPTH
+            //#pragma multi_compile_fog
+            #pragma multi_compile_instancing
+            #pragma instancing_options assumeuniformscaling
+            //#pragma multi_compile _DNENABLER_NONE _DNENABLER_USEDNTEXTURE
+            #define PROJECTION_YES //To identify the pass in the vert/frag shaders
+            #define PROJECTION_MOVER
+            #define WASH
+            #define VRSL_AUDIOLINK
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines.cginc" //Property Defines are here
+
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float3 texcoord : TEXCOORD1;
+                float4 color : COLOR;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float4 projectionorigin : TEXCOORD2;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float4 audioGlobalFinalConeIntensity : TEXCOORD1;
+                float3 ray : TEXCOORD2;
+                float4 screenPos : TEXCOORD4;
+                float4 color : COLOR;
+                float3 normal : TEXCOORD3;
+                //float2 sector: TEXCOORD10;
+                float4 projectionorigin : TEXCOORD5;
+                float4 worldDirection : TEXCOORD6;
+                float4 worldPos : TEXCOORD7;
+                float3 viewDir : TEXCOORD8;
+                float4 emissionColor : TEXCOORD9;
+                //float3 intensityStrobeWidth : TEXCOORD9;
+                //float4 goboPlusSpinPanTilt : TEXCOORD11;
+                //float4 rgbColor : TEXCOORD12;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "../Shared/VRSL-AudioLink-Functions.cginc" //Custom Functions
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-ProjectionFrag.cginc" //Fragment Shader is here
+
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-Vertex.cginc" //Vertex Shader is here
+
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
 		SubShader
 	{
 		

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-VolumetricMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-VolumetricMesh.shader
@@ -146,6 +146,100 @@
 		//[KeywordEnum(None, UseDNTexture)] _DNEnabler ("Enable Depth Normal Texture", Float) = 0
 
 	}
+
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+        }
+        //Volumetric Pass
+
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Blend One [_BlendDst]
+            Cull Off
+            ZWrite Off
+            Lighting Off
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            //#pragma multi_compile_fog
+            #pragma multi_compile_local _ _MAGIC_NOISE_ON_HIGH
+            #pragma multi_compile_local _ _MAGIC_NOISE_ON_MED
+            #pragma multi_compile_local _ _USE_DEPTH_LIGHT
+            #pragma multi_compile_local _ _POTATO_MODE_ON
+            #pragma multi_compile_local _ _HQ_MODE
+            #pragma multi_compile_local _ _2D_NOISE_ON
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma multi_compile_instancing
+            #pragma instancing_options assumeuniformscaling
+            #define VOLUMETRIC_YES //To identify the pass in the vert/frag
+            #define WASH
+            #define VRSL_AUDIOLINK
+
+            #include "UnityCG.cginc"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-AudioLink-Functions.cginc" //Custom Functions
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float4 color : COLOR;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float2 uv2 : TEXCOORD3;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                centroid float2 uv : TEXCOORD0;
+                float blindingEffect : TEXCOORD1;
+                float4 worldPos : TEXCOORD2;
+                float4 color : TEXCOORD3;
+                float3 audioGlobalFinalIntensity : TEXCOORD4;
+                float2 camAngleLen : TEXCOORD5;
+                float4 screenPos : TEXCOORD6;
+                float4 pos : SV_POSITION;
+                float3 objPos : TEXCOORD7;
+                centroid float3 objNormal : TEXCOORD8;
+                float2 stripeInfo : TEXCOORD9;
+                float2 uvClone : TEXCOORD10;
+                float3 norm : TEXCOORD11;
+                float4 emissionColor : TEXCOORD12;
+                float2 uv2 : TEXCOORD13;
+                float4 worldDirection : TEXCOORD14;
+                float coneWidth : TEXCOORD15;
+                //float3 intensityStrobeGOBOSpinSpeed : TEXCOORD15;
+                //float4 rgbColor : TEXCOORD16;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-VolumetricFrag.cginc" //Fragment Shader is here
+
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-Vertex.cginc"
+            ENDCG
+        }
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
 		SubShader
 	{
 		

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Shared/VRSL-AudioLink-Functions-URP.hlsl
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Shared/VRSL-AudioLink-Functions-URP.hlsl
@@ -1,0 +1,245 @@
+#ifndef VRSL_AUDIOLINK_FUNCTIONS
+#define VRSL_AUDIOLINK_FUNCTIONS
+
+#define VRSL_AUDIOLINK
+#define UNIVERSAL_RENDER_PIPELINE
+#if defined(UNIVERSAL_RENDER_PIPELINE)
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+#include "../../Shared/VRSL-Defines-URP.hlsl"
+#define IF(a, b, c) lerp(b, c, step((fixed) (a), 0))
+
+#ifndef RAW
+#include "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
+#endif
+
+float4 RGBtoHSV(in float3 RGB)
+{
+    float3 HSV = 0;
+    HSV.z = max(RGB.r, max(RGB.g, RGB.b));
+    float M = min(RGB.r, min(RGB.g, RGB.b));
+    float C = HSV.z - M;
+    if (C != 0)
+    {
+        HSV.y = C / HSV.z;
+        float3 Delta = (HSV.z - RGB) / C;
+        Delta.rgb -= Delta.brg;
+        Delta.rg += float2(2, 4);
+        if (RGB.r >= HSV.z)
+            HSV.x = Delta.b;
+        else if (RGB.g >= HSV.z)
+            HSV.x = Delta.r;
+        else
+            HSV.x = Delta.g;
+        HSV.x = frac(HSV.x / 6);
+    }
+    return float4(HSV, 1);
+}
+
+float3 Hue(float H)
+{
+    float R = abs(H * 6 - 3) - 1;
+    float G = 2 - abs(H * 6 - 2);
+    float B = 2 - abs(H * 6 - 4);
+    return saturate(float3(R, G, B));
+}
+
+float4 HSVtoRGB(in float3 HSV)
+{
+    return float4(((Hue(HSV.x) - 1) * HSV.y + 1) * HSV.z, 1);
+}
+
+#ifndef RAW
+inline float AudioLinkLerp3_g5(int Band, float Delay)
+{
+    return AudioLinkLerp(ALPASS_AUDIOLINK + float2(Delay, Band)).r;
+}
+#endif
+
+uint checkPanInvertY()
+{
+    return (uint)UNITY_ACCESS_INSTANCED_PROP(Props, _PanInvert);
+}
+
+uint checkTiltInvertZ()
+{
+    return (uint)UNITY_ACCESS_INSTANCED_PROP(Props, _TiltInvert);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+float4 GetTextureSampleColor()
+{
+    float4 rawColor = SAMPLE_TEXTURE2D_LOD(
+        _SamplingTexture, sampler_SamplingTexture,
+        float2(UNITY_ACCESS_INSTANCED_PROP(Props, _TextureColorSampleX), UNITY_ACCESS_INSTANCED_PROP(Props,
+            _TextureColorSampleY)),
+        0);
+
+    float4 h = RGBtoHSV(rawColor.rgb);
+    h.z = 1.0;
+
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _UseTraditionalSampling) > 0
+               ? rawColor * _RenderTextureMultiplier
+               : (HSVtoRGB(h) * _RenderTextureMultiplier);
+}
+
+float4 GetThemeSampleColor()
+{
+    switch (UNITY_ACCESS_INSTANCED_PROP(Props, _ThemeColorTarget))
+    {
+    case 1:
+        return AudioLinkData(ALPASS_THEME_COLOR0);
+    case 2:
+        return AudioLinkData(ALPASS_THEME_COLOR1);
+    case 3:
+        return AudioLinkData(ALPASS_THEME_COLOR2);
+    case 4:
+        return AudioLinkData(ALPASS_THEME_COLOR3);
+    default:
+        return float4(0, 0, 0, 1);
+    }
+}
+
+uint isStrobe()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _EnableStrobe);
+}
+
+uint instancedGOBOSelection()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _ProjectionSelection);
+}
+
+float getOffsetX()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _FixtureRotationX);
+}
+
+float getOffsetY()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _FixtureBaseRotationY);
+}
+
+float getStrobeFreq()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _StrobeFreq);
+}
+
+#ifdef RAW
+    float4 getEmissionColor()
+    {
+        float4 emissiveColor = UNITY_ACCESS_INSTANCED_PROP(Props, _Emission);
+        return IF(UNITY_ACCESS_INSTANCED_PROP(Props, _EnableColorTextureSample) > 0,
+                ((emissiveColor.r + emissiveColor.g + emissiveColor.b)/3.0) * GetTextureSampleColor(),
+                emissiveColor);
+    }
+#endif
+
+float getConeWidth()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _ConeWidth) - 1.25;
+}
+
+uint isGOBOSpin()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _EnableSpin);
+}
+
+float getConeLength()
+{
+    #ifdef RAW
+        return UNITY_ACCESS_INSTANCED_PROP(Props, _ConeLength) + 10.0f;
+    #else
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _ConeLength);
+    #endif
+}
+
+float getMaxConeLength()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _MaxConeLength);
+}
+
+float getGlobalIntensity()
+{
+    return lerp(1.0, UNITY_ACCESS_INSTANCED_PROP(Props, _GlobalIntensity),
+                UNITY_ACCESS_INSTANCED_PROP(Props, _GlobalIntensityBlend));
+}
+
+float getFinalIntensity()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _FinalIntensity);
+}
+
+#ifndef RAW ///////////////////////////////////////////////////////////////////////////////////////
+float getNumBands()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _NumBands);
+}
+
+float getBand()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _Band);
+}
+
+float getDelay()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _Delay);
+}
+
+float getBandMultiplier()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _BandMultiplier);
+}
+
+float checkIfAudioLink()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _EnableAudioLink);
+}
+
+uint checkIfColorChord()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _EnableColorChord);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+
+float GetAudioReactAmplitude()
+{
+    if (checkIfAudioLink() > 0)
+    {
+        return AudioLinkLerp3_g5(getBand(), getDelay()) * getBandMultiplier();
+    }
+    else
+    {
+        return 1;
+    }
+}
+
+float4 GetColorChordLight()
+{
+    return AudioLinkData(ALPASS_CCLIGHTS).rgba;
+}
+
+float4 getEmissionColor()
+{
+    float4 emissiveColor = UNITY_ACCESS_INSTANCED_PROP(Props, _Emission);
+    float4 col = UNITY_ACCESS_INSTANCED_PROP(Props, _EnableColorTextureSample) > 0
+                     ? ((emissiveColor.r + emissiveColor.g + emissiveColor.b) / 3.0) * GetTextureSampleColor()
+                     : emissiveColor;
+
+    col = UNITY_ACCESS_INSTANCED_PROP(Props, _EnableThemeColorSampling) > 0
+              ? ((emissiveColor.r + emissiveColor.g + emissiveColor.b) / 3.0) * GetThemeSampleColor()
+              : col;
+
+    return checkIfColorChord() == 1 ? GetColorChordLight() * 1.5 : col;
+}
+#endif
+
+float getGoboSpinSpeed()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _SpinSpeed);
+}
+
+#endif
+#endif

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Shared/VRSL-AudioLink-Functions-URP.hlsl.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Shared/VRSL-AudioLink-Functions-URP.hlsl.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d584c08db3b945d78bb22f342f0a6fc3
+timeCreated: 1747450510

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-FixtureMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-FixtureMesh.shader
@@ -53,6 +53,391 @@
     }
     SubShader
     {
+        Tags
+        {
+            "RenderType" = "Opaque" "RenderingPipeline" = "UniversalPipeline"
+        }
+        LOD 200
+
+        Pass
+        {
+            Name "ForwardLit"
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #pragma target 3.0
+
+            // URP Keywords
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+            #pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+            #pragma multi_compile _ SHADOWS_SHADOWMASK
+            #pragma multi_compile_fog
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+
+            #define STATIC_FIXTURE
+            #define VRSL_AUDIOLINK
+            #define VRSL_SURFACE
+
+            #include "../../Shared/VRSL-Defines-URP.hlsl"
+            #include "../Shared/VRSL-AudioLink-Functions-URP.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normalOS : NORMAL;
+                float4 tangentOS : TANGENT;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                #endif
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 positionWS : TEXCOORD1;
+                float3 normalWS : TEXCOORD2;
+                float4 tangentWS : TEXCOORD3;
+                float3 viewDirWS : TEXCOORD4;
+                half4 fogFactorAndVertexLight : TEXCOORD5;
+                #ifdef _MAIN_LIGHT_SHADOWS
+                float4 shadowCoord : TEXCOORD6;
+                #endif
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+                #endif
+            };
+
+            Varyings vert(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_TRANSFER_INSTANCE_ID(input, output);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+                VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+                VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+                output.positionCS = vertexInput.positionCS;
+                output.positionWS = vertexInput.positionWS;
+                output.uv = TRANSFORM_TEX(input.uv, _MainTex);
+                output.normalWS = normalInput.normalWS;
+
+                real sign = input.tangentOS.w * GetOddNegativeScale();
+                output.tangentWS = float4(normalInput.tangentWS.xyz, sign);
+                output.viewDirWS = GetWorldSpaceViewDir(vertexInput.positionWS);
+
+                // Vertex lighting and fog
+                half3 vertexLight = VertexLighting(vertexInput.positionWS, normalInput.normalWS);
+                half fogFactor = ComputeFogFactor(vertexInput.positionCS.z);
+                output.fogFactorAndVertexLight = half4(fogFactor, vertexLight);
+
+                #ifdef _MAIN_LIGHT_SHADOWS
+                output.shadowCoord = GetShadowCoord(vertexInput);
+                #endif
+                #endif
+
+                return output;
+            }
+
+            half4 frag(Varyings input) : SV_Target
+            {
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+                // Sample textures
+                half4 albedoAlpha = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv) * _Color;
+                half3 normalTS = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv));
+
+                // Setup SurfaceData
+                SurfaceData surfaceData = (SurfaceData)0;
+                surfaceData.albedo = albedoAlpha.rgb;
+                surfaceData.alpha = albedoAlpha.a;
+                surfaceData.metallic = _Metallic;
+                surfaceData.smoothness = _Glossiness;
+                surfaceData.normalTS = normalTS;
+
+                // Convert TBN from TS to WS
+                float3 normalWS = TransformTangentToWorld(
+                    normalTS,
+                    half3x3(input.tangentWS.xyz, cross(input.normalWS, input.tangentWS.xyz) * input.tangentWS.w,
+                                          input.normalWS)
+                );
+                normalWS = normalize(normalWS);
+
+                // Calculate shadow coords
+                #ifdef _MAIN_LIGHT_SHADOWS
+                float4 shadowCoord = input.shadowCoord;
+                #else
+                float4 shadowCoord = float4(0, 0, 0, 0);
+                #endif
+
+                // Setup InputData
+                InputData inputData = (InputData)0;
+                inputData.positionWS = input.positionWS;
+                inputData.normalWS = normalWS;
+                inputData.viewDirectionWS = SafeNormalize(input.viewDirWS);
+                inputData.shadowCoord = shadowCoord;
+                inputData.fogCoord = input.fogFactorAndVertexLight.x;
+                inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
+                inputData.bakedGI = SampleSH(normalWS);
+
+                // Emission calculation
+                half4 e = getEmissionColor();
+                e = clamp(e, half4(0, 0, 0, 1),
+                half4(_FixtureMaxIntensity * 2, _FixtureMaxIntensity * 2, _FixtureMaxIntensity * 2, 1));
+                e *= SAMPLE_TEXTURE2D(_EmissionMask, sampler_EmissionMask, input.uv).r;
+                e *= _FixutreIntensityMultiplier;
+                half3 emission = (e.rgb * _FixtureMaxIntensity) * GetAudioReactAmplitude();
+                emission = (emission * getGlobalIntensity()) * getFinalIntensity();
+                emission = emission * _UniversalIntensity;
+
+                // Add emission to surface data
+                surfaceData.emission = emission;
+
+                // Calculate lighting
+                half4 color = UniversalFragmentPBR(inputData, surfaceData);
+
+                // Apply fog
+                color.rgb = MixFog(color.rgb, inputData.fogCoord);
+
+                return color;
+                #else
+                return (0).xxxx;
+                #endif
+            }
+            ENDHLSL
+        }
+
+        // URP shadow casting pass
+        // ShadowCaster Pass
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags
+            {
+                "LightMode" = "ShadowCaster"
+            }
+
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex ShadowPassVertex
+            #pragma fragment ShadowPassFragment
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl"
+
+            #include "../../Shared/VRSL-Defines-URP.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+            };
+
+            float3 _LightDirection;
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            float4 GetShadowPositionHClip(Attributes input)
+            {
+                float3 positionWS = TransformObjectToWorld(input.positionOS.xyz);
+                float3 normalWS = TransformObjectToWorldNormal(input.normalOS);
+
+                float4 positionCS = TransformWorldToHClip(ApplyShadowBias(positionWS, normalWS, _LightDirection));
+
+                #if UNITY_REVERSED_Z
+                positionCS.z = min(positionCS.z, positionCS.w * UNITY_NEAR_CLIP_VALUE);
+                #else
+                    positionCS.z = max(positionCS.z, positionCS.w * UNITY_NEAR_CLIP_VALUE);
+                #endif
+
+                return positionCS;
+            }
+            #endif
+
+            Varyings ShadowPassVertex(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                output.positionCS = GetShadowPositionHClip(input);
+                #endif
+                return output;
+            }
+
+            half4 ShadowPassFragment(Varyings input) : SV_TARGET
+            {
+                return 0;
+            }
+            ENDHLSL
+        }
+
+        // URP depth-only pass
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex DepthOnlyVertex
+            #pragma fragment DepthOnlyFragment
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            #include "../../Shared/VRSL-Defines-URP.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                float4 position : POSITION;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+            };
+
+            Varyings DepthOnlyVertex(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                output.positionCS = TransformObjectToHClip(input.position.xyz);
+                #endif
+                return output;
+            }
+
+            half4 DepthOnlyFragment(Varyings input) : SV_TARGET
+            {
+                return 0;
+            }
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex DepthNormalsVertex
+            #pragma fragment DepthNormalsFragment
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            #include "../../Shared/VRSL-Defines-URP.hlsl"
+
+            TEXTURE2D(_NormalMap);
+            SAMPLER(sampler_NormalMap);
+            #endif
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float4 tangentOS : TANGENT;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normalWS : TEXCOORD1;
+                float4 tangentWS : TEXCOORD2;
+            };
+
+            Varyings DepthNormalsVertex(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                output.positionCS = TransformObjectToHClip(input.positionOS.xyz);
+                output.uv = TRANSFORM_TEX(input.texcoord, _MainTex);
+
+                VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+                output.normalWS = normalInput.normalWS;
+
+                real sign = input.tangentOS.w * GetOddNegativeScale();
+                output.tangentWS = float4(normalInput.tangentWS.xyz, sign);
+                #endif
+                return output;
+            }
+
+            half4 DepthNormalsFragment(Varyings input) : SV_TARGET
+            {
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                // Read normal map
+                float3 normalTS = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv));
+
+                // Calculate tangent space to world space matrix
+                float3 tangentWS = normalize(input.tangentWS.xyz);
+                float3 bitangentWS = normalize(cross(input.normalWS, tangentWS) * input.tangentWS.w);
+
+                // Transform normal from tangent to world space
+                float3x3 tangentToWorld = float3x3(tangentWS, bitangentWS, input.normalWS);
+                float3 normalWS = normalize(mul(normalTS, tangentToWorld));
+
+                // Convert normal from [-1,1] to [0,1] range
+                float3 normalViewSpace = TransformWorldToViewDir(normalWS) * 0.5 + 0.5;
+
+                return half4(normalViewSpace, 0);
+                #else
+                return (0).xxxx;
+                #endif
+            }
+            ENDHLSL
+        }
+    }
+
+    SubShader
+    {
         Tags { "RenderType"="Opaque" }
         LOD 200
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-LensFlare.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-LensFlare.shader
@@ -67,6 +67,323 @@
     }
     SubShader
     {
+        Tags
+        {
+            "RenderType"="Transparent" "Queue" = "Transparent+200" "RenderingPipeline" = "UniversalPipeline"
+        }
+        LOD 100
+
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Zwrite Off
+            ZTest Off
+            Blend One [_BlendDst]
+            Cull Back
+            Lighting Off
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            // make fog work
+            #pragma multi_compile_local _ _USE_DEPTH_LIGHT
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma multi_compile_fog
+            #pragma multi_compile_instancing
+            #define VRSL_AUDIOLINK
+            #define VRSL_FLARE
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                half4 color : COLOR;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                UNITY_FOG_COORDS(1)
+                float4 vertex : SV_POSITION;
+                float4 screenPos : TEXCOORD6;
+                float4 worldDirection : TEXCOORD2;
+                float4 vertexWorldPos : TEXCOORD3;
+                half4 color : TEXCOORD4;
+                float maskX : TEXCOORD5;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                // will turn into this in non OpenGL / non PSSL -> uint instanceID : SV_InstanceID;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #define COUNT 8 //you can edit to any number(e.g. 1~32), the lower the faster. Keeping this number a const can enable many compiler optimizations
+
+            // sampler2D _MainTex;
+            //float4 _MainTex_ST;
+            //half4 _Emission;
+            half _ColorSat, _ScaleFactor, _ReferenceDistance, _UVScale;
+            float _LightSourceViewSpaceRadius;
+            float _DepthOcclusionTestZBias;
+
+            float _StartFadeinDistanceWorldUnit;
+            float _EndFadeinDistanceWorldUnit;
+
+            float _UsePreMultiplyAlpha;
+
+            //  float _FlickerAnimSpeed;
+            float _FlickResultIntensityLowestPoint;
+            //float _ShouldDoFlicker;
+            half _RemoveTextureArtifact, _CurveMod;
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-AudioLink-Functions.cginc"
+
+            float4x4 GetWorldToViewMatrix()
+            {
+                return UNITY_MATRIX_V;
+            }
+
+            float4x4 GetObjectToWorldMatrix()
+            {
+                return UNITY_MATRIX_M;
+            }
+
+            float3 TransformWorldToView(float3 positionWS)
+            {
+                return mul(GetWorldToViewMatrix(), float4(positionWS, 1.0)).xyz;
+            }
+
+            float3 TransformObjectToWorld(float3 vertex)
+            {
+                return mul(GetObjectToWorldMatrix(), float4(vertex, 1.0)).xyz;
+            }
+
+            inline float4 CalculateFrustumCorrection()
+            {
+                float x1 = -UNITY_MATRIX_P._31 / (UNITY_MATRIX_P._11 * UNITY_MATRIX_P._34);
+                float x2 = -UNITY_MATRIX_P._32 / (UNITY_MATRIX_P._22 * UNITY_MATRIX_P._34);
+                return float4(
+                    x1, x2, 0,
+                    UNITY_MATRIX_P._33 / UNITY_MATRIX_P._34 + x1 * UNITY_MATRIX_P._13 + x2 * UNITY_MATRIX_P._23);
+            }
+
+            //CREDIT TO DJ LUKIS FOR MIRROR DEPTH CORRECTION
+            inline float CorrectedLinearEyeDepth(float z, float B)
+            {
+                return 1.0 / (z / UNITY_MATRIX_P._34 + B);
+            }
+
+            float3 RGB2HSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            float3 hsb2rgb(float3 c)
+            {
+                float3 rgb = clamp(abs(fmod(c.x * 6.0 + float3(0.0, 4.0, 2.0), 6) - 3.0) - 1.0, 0, 1);
+                rgb = rgb * rgb * (3.0 - 2.0 * rgb);
+                return c.z * lerp(float3(1, 1, 1), rgb, c.y);
+            }
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v); //Insert
+                    UNITY_INITIALIZE_OUTPUT(v2f, o); //Insert
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o); //Insert
+
+                half4 e = getEmissionColor();
+                e = clamp(e, half4(0, 0, 0, 1),
+                    half4(_FixtureMaxIntensity * 2, _FixtureMaxIntensity * 2, _FixtureMaxIntensity * 2, 1));
+                #ifdef _ALPHATEST_ON
+                    e*= (_FixutreIntensityMultiplier*0.25);
+                #else
+                e *= _FixutreIntensityMultiplier;
+                #endif
+                e *= GetAudioReactAmplitude();
+                e = float4(((e.rgb * _FixtureMaxIntensity) * getGlobalIntensity()) * getFinalIntensity(), e.w);
+                e *= _UniversalIntensity;
+                float3 eHSV = RGB2HSV(e.rgb);
+                if (eHSV.z <= 0.01)
+                {
+                    v.vertex = float4(0, 0, 0, 0);
+                    o.vertex = UnityObjectToClipPos(v.vertex);
+                    return o;
+                }
+
+
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                o.color = v.color * e;
+                float3 quadPivotPosOS = float3(0, 0, 0);
+                float3 quadPivotPosWS = TransformObjectToWorld(quadPivotPosOS);
+                float3 quadPivotPosVS = TransformWorldToView(quadPivotPosWS);
+
+                //get transform.lossyScale using:
+                //https://forum.unity.com/threads/can-i-get-the-scale-in-the-transform-of-the-object-i-attach-a-shader-to-if-so-how.418345/
+                float2 scaleXY_WS = float2(
+                    length(float3(GetObjectToWorldMatrix()[0].x, GetObjectToWorldMatrix()[1].x,
+                    GetObjectToWorldMatrix()[2].x)), // scale x axis
+                    length(float3(GetObjectToWorldMatrix()[0].y, GetObjectToWorldMatrix()[1].y,
+                    GetObjectToWorldMatrix()[2].y)) // scale y axis
+                );
+
+                float3 posVS = quadPivotPosVS + float3(v.vertex.xy * scaleXY_WS, 0);
+                //recontruct quad 4 points in view space
+
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //complete SV_POSITION's view space to HClip space transformation
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                o.vertex = mul(UNITY_MATRIX_P, float4(posVS, 1));
+
+
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //do smooth visibility test using brute force forloop (COUNT*2+1)^2 times inside a view space 2D grid area
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                float visibilityTestPassedCount = 0;
+                float linearEyeDepthOfFlarePivot = -quadPivotPosVS.z;
+                //view space's forward is pointing to -Z, but we want +Z, so negate it
+                float testLoopSingleAxisWidth = COUNT * 2 + 1;
+                float totalTestCount = testLoopSingleAxisWidth * testLoopSingleAxisWidth;
+                float divider = 1.0 / totalTestCount;
+                float maxSingleAxisOffset = _LightSourceViewSpaceRadius / testLoopSingleAxisWidth;
+
+                //Test for n*n grid in view space, where quad pivot is grid's center.
+                //For each iteration,
+                //if that test point passed the scene depth occlusion test, we add 1 to visibilityTestPassedCount
+                #if _USE_DEPTH_LIGHT
+                        for(int x = -COUNT; x <= COUNT; x++)
+                        {
+                            for(int y = -COUNT; y <= COUNT ; y++)
+                            {
+                                float3 testPosVS = quadPivotPosVS;
+                                testPosVS.xy += float2(x,y) * maxSingleAxisOffset;//add 2D test grid offset, in const view space unit
+                                float4 PivotPosCS = mul(UNITY_MATRIX_P,float4(testPosVS,1));
+                                float4 PivotScreenPos = ComputeScreenPos(PivotPosCS);
+                                float2 screenUV = PivotScreenPos.xy/PivotScreenPos.w;
+
+                                //if screenUV out of bound, treat it as occluded, because no correct depth texture data can be used to compare
+                                if(screenUV.x > 1 || screenUV.x < 0 || screenUV.y > 1 || screenUV.y < 0)
+                                    continue; //exit means occluded
+
+                                //we don't have tex2D() in vertex shader, because rasterization is not done by GPU, so we use tex2Dlod() with mip0 instead
+                                float4 ssd = SAMPLE_DEPTH_TEXTURE_LOD(_CameraDepthTexture, float4(screenUV, 0.0, 0.0));//(uv.x,uv.y,0,mipLevel)
+                                float sampledSceneDepth = ssd.x;
+                                float linearEyeDepthFromSceneDepthTexture = LinearEyeDepth(sampledSceneDepth);
+                                float linearEyeDepthFromSelfALU = PivotPosCS.w; //clip space .w is view space z, = linear eye depth
+
+                                //do the actual depth comparision test
+                                //+1 means flare test point is visible in screen space
+                                //+0 means flare test point blocked by other objects in screen space, not visible
+                                visibilityTestPassedCount += linearEyeDepthFromSelfALU + _DepthOcclusionTestZBias < linearEyeDepthFromSceneDepthTexture ? 1 : 0; 
+                            }
+                        }
+                        float visibilityResult01 = visibilityTestPassedCount * divider;//0~100% visiblility result 
+
+                        //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                        //if camera too close to flare , smooth fade out to prevent flare blocking camera too much (usually for fps games)
+                        //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                        visibilityResult01 *= smoothstep(_StartFadeinDistanceWorldUnit,_EndFadeinDistanceWorldUnit,linearEyeDepthOfFlarePivot);
+
+                        // if(_ShouldDoFlicker)
+                        // {
+                        //     float flickerMul = 0;
+                        //     //TODO: expose more control to noise? (send me an issue in GitHub, if anyone need this)
+                        //     flickerMul += saturate(sin(_Time.y * _FlickerAnimSpeed * 1.0000)) * (1-_FlickResultIntensityLowestPoint) + _FlickResultIntensityLowestPoint;
+                        //     flickerMul += saturate(sin(_Time.y * _FlickerAnimSpeed * 0.6437)) * (1-_FlickResultIntensityLowestPoint) + _FlickResultIntensityLowestPoint;   
+                        //     visibilityResult01 *= saturate(flickerMul/2);
+                        // }
+                        //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                        //apply all combinations(visibilityResult01) to vertex color
+                        //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                        o.color.a *= visibilityResult01;
+                        o.vertex = visibilityResult01 < divider ? 0 : o.vertex;
+                // }
+                #endif
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //premultiply alpha to rgb after alpha's calculation is done
+                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// 
+                o.color.rgb *= o.color.a;
+                //o.color.a = _UsePreMultiplyAlpha? o.color.a : 0;
+
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //pure optimization:
+                //if flare is invisible or nearly invisible,
+                //invalid this vertex (and all connected vertices).
+                //This 100% early exit at clipping stage will prevent any rasterization & fragment shader cost at all
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+                float3 hsvFC = RGB2HSV(o.color.xyz);
+                hsvFC.y = 0.0;
+                float4 e2 = float4(1, 1, 1, o.color.w) * hsvFC.z;
+                o.maskX = lerp(1, 0, pow(distance(half2(0.5, 0.5), o.uv), _FadeAmt));
+                float satMask = lerp(1, 0, pow(distance(half2(0.5, 0.5), o.uv), _ColorSat));
+                o.color = lerp(o.color, e2, satMask);
+
+                #if _ALPHATEST_ON
+                    o.screenPos = ComputeScreenPos(o.vertex);
+                #endif
+
+                //  UNITY_TRANSFER_FOG(o,o.vertex);
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                #if _ALPHATEST_ON
+                    float2 pos = i.screenPos.xy / i.screenPos.w;
+                    pos *= _ScreenParams.xy;
+                    float DITHER_THRESHOLDS[16] =
+                    {
+                        1.0 / 17.0,  9.0 / 17.0,  3.0 / 17.0, 11.0 / 17.0,
+                        13.0 / 17.0,  5.0 / 17.0, 15.0 / 17.0,  7.0 / 17.0,
+                        4.0 / 17.0, 12.0 / 17.0,  2.0 / 17.0, 10.0 / 17.0,
+                        16.0 / 17.0,  8.0 / 17.0, 14.0 / 17.0,  6.0 / 17.0
+                    };
+                    int index = (uint(pos.x) % 4) * 4 + uint(pos.y) % 4;
+                    float4 col = saturate(tex2D(_MainTex, i.uv ));
+                   // col *= i.maskX;
+                    //clip((col.a) - DITHER_THRESHOLDS[index]);
+                    // apply fog
+                    UNITY_APPLY_FOG(i.fogCoord, col);
+                    clip((((col.r + col.g + col.b)/3) * (_ClippingThreshold * 10)) - DITHER_THRESHOLDS[index]);
+                    return col * i.color;
+                #else
+                    fixed4 col = saturate(tex2D(_MainTex, i.uv) - _RemoveTextureArtifact) * i.color;
+                    // apply fog
+                    UNITY_APPLY_FOG(i.fogCoord, col);
+
+                    col *= i.maskX;
+                    return col;
+                #endif
+            }
+            ENDCG
+        }
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
+    SubShader
+    {
         Tags { "RenderType"="Transparent" "Queue" = "Transparent+200" }
         LOD 100
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-LensFlare.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-LensFlare.shader
@@ -287,6 +287,9 @@
                                 //we don't have tex2D() in vertex shader, because rasterization is not done by GPU, so we use tex2Dlod() with mip0 instead
                                 float4 ssd = SAMPLE_DEPTH_TEXTURE_LOD(_CameraDepthTexture, float4(screenUV, 0.0, 0.0));//(uv.x,uv.y,0,mipLevel)
                                 float sampledSceneDepth = ssd.x;
+                                #if !UNITY_REVERSED_Z
+                                sampledSceneDepth = lerp(UNITY_NEAR_CLIP_VALUE, 1, sampledSceneDepth);
+                                #endif
                                 float linearEyeDepthFromSceneDepthTexture = LinearEyeDepth(sampledSceneDepth);
                                 float linearEyeDepthFromSelfALU = PivotPosCS.w; //clip space .w is view space z, = linear eye depth
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-ProjectionMesh.shader
@@ -5,9 +5,7 @@
 	{
 		
 		//[Header (INSTANCED PROPERITES)]
-		 [Enum(UnityEngine.Rendering.BlendMode)] _BlendSrc ("Source Blend mode", Float) = 2
 		 //[Enum(UnityEngine.Rendering.BlendMode)] _BlendDst ("Destination Blend mode", Float) = 1
-		 [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp ("Blend Operation", Float) = 0
 		// _BlockLengthX("OSC Block Base Distance X", Float) = 0.019231
 		// _BlockLengthY("OSC Block Base Distance Y", Float) = 0
 
@@ -103,6 +101,7 @@
 		[Enum(Transparent,1,AlphaToCoverage,2)] _RenderMode ("Render Mode", Int) = 1
         [Enum(Off,0,On,1)] _ZWrite ("Z Write", Int) = 0
 		[Enum(Off,0,On,1)] _AlphaToCoverage ("Alpha To Coverage", Int) = 0
+        [Enum(UnityEngine.Rendering.BlendMode)] _BlendSrc ("Source Blend mode", Float) = 2
         [Enum(Off,0,One,1)] _BlendDst ("Destination Blend mode", Float) = 1
 		[Enum(UnityEngine.Rendering.BlendOp)] _BlendOp ("Blend Operation", Float) = 0
         _ClippingThreshold ("Clipping Threshold", Range (0,1)) = 0.5
@@ -111,10 +110,157 @@
 
 		[Enum(Off,0,On,1)] _MultiSampleDepth ("Multi Sample Depth", Int) = 1
 
-
-
-
 	}
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+        }
+        Pass
+        {
+
+            Tags
+            {
+                "ForceNoShadowCasting"="True" "IgnoreProjector"="True" "LightMode" = "UniversalForward"
+            }
+            Cull Front
+            Ztest GEqual
+            ZWrite Off
+            Blend [_BlendSrc] [_BlendDst]
+            BlendOp [_BlendOp]
+            Lighting Off
+            //SeparateSpecular Off
+
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_fog
+            #pragma multi_compile_instancing
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma shader_feature_local _MULTISAMPLEDEPTH
+            #define PROJECTION_YES
+            #define VRSL_AUDIOLINK
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float3 texcoord : TEXCOORD1;
+                float4 color : COLOR;
+                float3 normal : TEXCOORD3;
+                float3 tangent : TANGENT;
+                float4 projectionorigin : TEXCOORD2;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 ray : TEXCOORD2;
+                float4 screenPos : TEXCOORD4;
+                float4 color : COLOR;
+                float3 normal : TEXCOORD3;
+                float4 projectionorigin : TEXCOORD5;
+                float4 worldDirection : TEXCOORD6;
+                float4 worldPos : TEXCOORD7;
+                float4 emissionColor : TEXCOORD8;
+                float3 audioGlobalFinalIntensity: TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-AudioLink-Functions.cginc"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-ProjectionFrag.cginc"
+
+            #define IF(a, b, c) lerp(b, c, step((fixed) (a), 0));
+
+            float4 CalculateProjectionScaleRange(appdata v, float4 input, float scalar)
+            {
+                float4 oldinput = input;
+                float4x4 scaleMatrix = float4x4(scalar, 0, 0, 0,
+                                               0, scalar, 0, 0,
+                                               0, 0, scalar, 0,
+                                               0, 0, 0, 1.0);
+                float4 newOrigin = input.w * _ProjectionRangeOrigin;
+                input.xyz = input.xyz - newOrigin;
+                //Do stretch
+                float4 newProjectionScale = mul(scaleMatrix, input);
+                input.xyz = newProjectionScale;
+                input.xyz = input.xyz + newOrigin;
+                input.xyz = IF(v.color.g != 0, input.xyz, oldinput);
+                return input;
+            }
+
+            inline float4 CalculateFrustumCorrection()
+            {
+                float x1 = -UNITY_MATRIX_P._31 / (UNITY_MATRIX_P._11 * UNITY_MATRIX_P._34);
+                float x2 = -UNITY_MATRIX_P._32 / (UNITY_MATRIX_P._22 * UNITY_MATRIX_P._34);
+                return float4(
+                    x1, x2, 0,
+                    UNITY_MATRIX_P._33 / UNITY_MATRIX_P._34 + x1 * UNITY_MATRIX_P._13 + x2 * UNITY_MATRIX_P._23);
+            }
+
+            //VERTEX SHADER
+            v2f vert(appdata v)
+            {
+                v2f o;
+                    UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                o.audioGlobalFinalIntensity.x = GetAudioReactAmplitude();
+                o.audioGlobalFinalIntensity.y = getGlobalIntensity();
+                o.audioGlobalFinalIntensity.z = getFinalIntensity();
+                o.emissionColor = getEmissionColor();
+                v.vertex = CalculateProjectionScaleRange(v, v.vertex, _ProjectionRange);
+                o.projectionorigin = CalculateProjectionScaleRange(v, _ProjectionRangeOrigin, _ProjectionRange);
+                //move verts to clip space
+                o.pos = UnityObjectToClipPos(v.vertex);
+
+                //get screen space position of verts
+                o.screenPos = ComputeScreenPos(o.pos);
+                //Putting in the vertex position before the transformation seems to somewhat move the projection correctly, but is still incorrect...?
+                o.ray = UnityObjectToViewPos(v.vertex).xyz;
+                //invert z axis so that it projects from camera properly
+                o.ray *= float3(1, 1, -1);
+                //saving vertex color incase needing to perform rotation calculation in fragment shader
+                o.color = v.color;
+                o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+                //For Mirror Depth Correction
+                o.worldDirection.xyz = o.worldPos.xyz - _WorldSpaceCameraPos;
+                // pack correction factor into direction w component to save space
+                o.worldDirection.w = dot(o.pos, CalculateFrustumCorrection());
+                if (o.audioGlobalFinalIntensity.x <= 0.005 || o.audioGlobalFinalIntensity.y <= 0.005 || o.
+                    audioGlobalFinalIntensity.z <= 0.005 ||
+                    all(o.emissionColor.xyz <= float4(0.005, 0.005, 0.005, 1.0)))
+                {
+                    v.vertex = float4(0, 0, 0, 0);
+                    o.pos = UnityObjectToClipPos(v.vertex);
+                }
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                //UNITY_SETUP_INSTANCE_ID(i);
+                return ProjectionFrag(i);
+            }
+            ENDCG
+
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
 		SubShader
 	{
 		//UNITY_REQUIRE_ADVANDED_BLEND(all_equations)

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-ProjectionMesh.shader
@@ -175,6 +175,7 @@
                 float4 emissionColor : TEXCOORD8;
                 float3 audioGlobalFinalIntensity: TEXCOORD1;
                 UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
             };
 
             #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines.cginc"
@@ -213,8 +214,9 @@
             v2f vert(appdata v)
             {
                 v2f o;
-                    UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
                 UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 UNITY_TRANSFER_INSTANCE_ID(v, o);
                 o.audioGlobalFinalIntensity.x = GetAudioReactAmplitude();
                 o.audioGlobalFinalIntensity.y = getGlobalIntensity();

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-AlphaCutout.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-AlphaCutout.shader
@@ -42,6 +42,338 @@
     }
     SubShader
     {
+        Tags
+        {
+            "Queue" = "AlphaTest" "RenderType"="TransparentCutout" "RenderPipeline" = "UniversalPipeline"
+        }
+        LOD 200
+
+        Pass
+        {
+            Name "ForwardLit"
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #pragma multi_compile_fog
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS_CASCADE
+            #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma shader_feature _1CH_MODE _4CH_MODE _5CH_MODE _13CH_MODE
+
+            #define VRSL_DMX
+
+            // Use shader model 3.5 target, to get nicer looking lighting
+            #pragma target 3.5
+
+            #if UNIVERSAL_RENDER_PIPELINE
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines-URP.hlsl"
+            #include "../Shared/VRSL-DMXFunctions-URP.hlsl"
+            #include "VRSL-StandardSurface-Functions-URP.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float4 tangentOS : TANGENT;
+                float2 uv : TEXCOORD0;
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                #endif
+            };
+
+            struct Varyings
+            {
+                float2 uv_MainTex : TEXCOORD0;
+                float2 uv_EmissionMask : TEXCOORD1;
+                float2 uv_NormalMap : TEXCOORD2;
+                float2 uv_MetallicSmoothness : TEXCOORD3;
+                float3 normalWS : TEXCOORD4;
+                float3 tangentWS : TEXCOORD5;
+                float3 bitangentWS : TEXCOORD6;
+                float3 positionWS : TEXCOORD7;
+                float4 positionCS : SV_POSITION;
+                float fogCoord : TEXCOORD8;
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+                #endif
+            };
+
+            #if UNIVERSAL_RENDER_PIPELINE
+            TEXTURE2D(_EmissionMask);
+            SAMPLER(sampler_EmissionMask);
+            TEXTURE2D(_NormalMap);
+            SAMPLER(sampler_NormalMap);
+            TEXTURE2D(_MetallicSmoothness);
+            SAMPLER(sampler_MetallicSmoothness);
+
+            CBUFFER_START(UnityPerMaterial)
+                float4 _EmissionMask_ST;
+                float4 _NormalMap_ST;
+                float4 _MetallicSmoothness_ST;
+                half _CurveMod;
+                half _AlphaIntensity;
+                half _EnableAlphaDMX;
+                half _Cutoff;
+            CBUFFER_END
+            #endif
+
+            Varyings vert(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+                UNITY_TRANSFER_INSTANCE_ID(input, output);
+                // Transform positions and normals
+                VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+                VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+                // Copy values to output
+                output.positionWS = vertexInput.positionWS;
+                output.positionCS = vertexInput.positionCS;
+                output.normalWS = normalInput.normalWS;
+                output.tangentWS = normalInput.tangentWS;
+                output.bitangentWS = normalInput.bitangentWS;
+
+                // UVs
+                output.uv_MainTex = TRANSFORM_TEX(input.uv, _MainTex);
+                output.uv_EmissionMask = TRANSFORM_TEX(input.uv, _EmissionMask);
+                output.uv_NormalMap = TRANSFORM_TEX(input.uv, _NormalMap);
+                output.uv_MetallicSmoothness = TRANSFORM_TEX(input.uv, _MetallicSmoothness);
+
+                // Fog
+                output.fogCoord = ComputeFogFactor(vertexInput.positionCS.z);
+                #endif
+                return output;
+            }
+
+            half4 frag(Varyings input) : SV_Target
+            {
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+                // Sample textures
+                half4 mainTex = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv_MainTex) * _Color;
+                half4 ms = SAMPLE_TEXTURE2D(_MetallicSmoothness, sampler_MetallicSmoothness,
+                                                                             input.uv_MetallicSmoothness);
+                half3 normalTS = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv_NormalMap));
+
+                // Alpha calculation based on DMX mode
+                half alpha = mainTex.a;
+                half3 emission = half3(0, 0, 0);
+
+                #if _1CH_MODE
+                emission = GetDMXEmission1CH(input.uv_EmissionMask) * _CurveMod;
+                alpha *= lerp(1.0, 0.0, GetDMXAlpha(getDMXChannel() + 1, _EnableAlphaDMX)) * _AlphaIntensity;
+                #elif _4CH_MODE
+                emission = GetDMXEmission4CH(input.uv_EmissionMask) * _CurveMod;
+                alpha *= lerp(1.0, 0.0, GetDMXAlpha(getDMXChannel()+4, _EnableAlphaDMX)) * _AlphaIntensity;
+                #elif _5CH_MODE
+                emission = GetDMXEmission5CH(input.uv_EmissionMask) * _CurveMod;
+                alpha *= lerp(1.0, 0.0, GetDMXAlpha(getDMXChannel()+5, _EnableAlphaDMX)) * _AlphaIntensity;
+                #elif _13CH_MODE
+                emission = GetDMXEmission13CH(input.uv_EmissionMask) * _CurveMod;
+                alpha *= lerp(1.0, 0.0, GetDMXAlpha(getDMXChannel()+10, _EnableAlphaDMX)) * _AlphaIntensity;
+                #endif
+
+                // Alpha cutout
+                clip(alpha - _Cutoff);
+
+                // Transform normal from tangent to world space
+                float3x3 tangentToWorld = float3x3(
+                    normalize(input.tangentWS),
+                    normalize(input.bitangentWS),
+                    normalize(input.normalWS)
+                );
+
+                float3 normalWS = TransformTangentToWorld(normalTS, tangentToWorld);
+
+                // PBR inputs
+                InputData lightingInput = (InputData)0;
+                lightingInput.positionWS = input.positionWS;
+                lightingInput.normalWS = normalize(normalWS);
+                lightingInput.viewDirectionWS = GetWorldSpaceNormalizeViewDir(input.positionWS);
+                lightingInput.shadowCoord = TransformWorldToShadowCoord(input.positionWS);
+                lightingInput.fogCoord = input.fogCoord;
+                lightingInput.vertexLighting = half3(0, 0, 0);
+                lightingInput.bakedGI = half3(0, 0, 0); // If using baked lighting, sample SH here
+                lightingInput.normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(input.positionCS);
+                lightingInput.shadowMask = half4(1, 1, 1, 1);
+
+                // Surface data
+                SurfaceData surfaceData = (SurfaceData)0;
+                surfaceData.albedo = mainTex.rgb;
+                surfaceData.metallic = _Metallic * ms.r;
+                surfaceData.specular = half3(0, 0, 0);
+                surfaceData.smoothness = _Glossiness * ms.a;
+                surfaceData.occlusion = 1.0;
+                surfaceData.emission = emission;
+                surfaceData.alpha = alpha;
+                surfaceData.clearCoatMask = 0;
+                surfaceData.clearCoatSmoothness = 0;
+                surfaceData.normalTS = normalTS;
+
+                // Calculate final lighting
+                half4 finalColor = UniversalFragmentPBR(lightingInput, surfaceData);
+
+                // Apply fog
+                finalColor.rgb = MixFog(finalColor.rgb, input.fogCoord);
+
+                return finalColor;
+                #else
+            return (0).xxxx;
+                #endif
+            }
+            ENDHLSL
+        }
+
+        // DepthOnly Pass, Required for depth priming
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex DepthOnlyVertex
+            #pragma fragment DepthOnlyFragment
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            #include "../Shared/VRSL-Defines-URP.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                float4 position : POSITION;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+            };
+
+            Varyings DepthOnlyVertex(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                output.positionCS = TransformObjectToHClip(input.position.xyz);
+                #endif
+                return output;
+            }
+
+            half4 DepthOnlyFragment(Varyings input) : SV_TARGET
+            {
+                return 0;
+            }
+            ENDHLSL
+        }
+        // DepthNormals Pass, Required for depth priming
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex DepthNormalsVertex
+            #pragma fragment DepthNormalsFragment
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            #include "../Shared/VRSL-Defines-URP.hlsl"
+
+            TEXTURE2D(_NormalMap);
+            SAMPLER(sampler_NormalMap);
+            #endif
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float4 tangentOS : TANGENT;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normalWS : TEXCOORD1;
+                float4 tangentWS : TEXCOORD2;
+            };
+
+            Varyings DepthNormalsVertex(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                output.positionCS = TransformObjectToHClip(input.positionOS.xyz);
+                output.uv = TRANSFORM_TEX(input.texcoord, _MainTex);
+
+                VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+                output.normalWS = normalInput.normalWS;
+
+                real sign = input.tangentOS.w * GetOddNegativeScale();
+                output.tangentWS = float4(normalInput.tangentWS.xyz, sign);
+                #endif
+                return output;
+            }
+
+            half4 DepthNormalsFragment(Varyings input) : SV_TARGET
+            {
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                // Read normal map
+                float3 normalTS = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv));
+
+                // Calculate tangent space to world space matrix
+                float3 tangentWS = normalize(input.tangentWS.xyz);
+                float3 bitangentWS = normalize(cross(input.normalWS, tangentWS) * input.tangentWS.w);
+
+                // Transform normal from tangent to world space
+                float3x3 tangentToWorld = float3x3(tangentWS, bitangentWS, input.normalWS);
+                float3 normalWS = normalize(mul(normalTS, tangentToWorld));
+
+                // Convert normal from [-1,1] to [0,1] range
+                float3 normalViewSpace = TransformWorldToViewDir(normalWS) * 0.5 + 0.5;
+
+                return half4(normalViewSpace, 0);
+                #else
+                return (0).xxxx;
+                #endif
+            }
+            ENDHLSL
+        }
+    }
+
+    SubShader
+    {
 
         Tags {"Queue" = "AlphaTest" "RenderType"="TransparentCutout"  }
         LOD 200

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Functions-URP.hlsl
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Functions-URP.hlsl
@@ -1,0 +1,273 @@
+#ifndef VRSL_STANDARD_SURF_FUNCTIONS
+#define VRSL_STANDARD_SURF_FUNCTIONS
+
+#if defined(UNIVERSAL_PIPELINE_CORE_INCLUDED)
+
+#include "../Shared/VRSL-DMXFunctions-URP.hlsl"
+
+float GetSurfaceStrobe(uint DMXChannel)
+{
+    half strobe = getValueAtCoords(DMXChannel + 4, TEXTURE2D_ARGS(_Udon_DMXGridStrobeOutput, sampler_Udon_DMXGridStrobeOutput));
+    
+    //check if we should even be strobing at all.
+    strobe = IF(isDMX() == 1, strobe, 1);
+    strobe = IF(isStrobe() == 1, strobe, 1);
+    
+    return strobe;
+}
+
+float4 GetDMXRGB(uint DMXChannel, float intensity, uint channelOffset)
+{
+    float redchannel = getValueAtCoords(DMXChannel + 1 + channelOffset, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+    float greenchannel = getValueAtCoords(DMXChannel + 2 + channelOffset, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+    float bluechannel = getValueAtCoords(DMXChannel + 3 + channelOffset, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+
+    #if defined(PROJECTION_YES)
+        redchannel = redchannel * _RedMultiplier;
+        bluechannel = bluechannel * _BlueMultiplier;
+        greenchannel = greenchannel * _GreenMultiplier;
+    #endif
+    
+    return lerp(float4(0,0,0,1), float4(redchannel,greenchannel,bluechannel,1), intensity);
+}
+
+float GetDMXAlpha(uint DMXChannel, float enableDMXControl)
+{
+    return IF(isDMX() == 1 && enableDMXControl == 1, getValueAtCoords(DMXChannel, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture)), 0.0);
+}
+
+float GetDMX12CH(uint DMXChannel, int dimmerChannel)
+{
+    int startChannel = (int)DMXChannel + 2 + dimmerChannel;
+    float dimmer = getValueAtCoords(startChannel, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+    return dimmer;
+}
+
+float4 GetDMX12CHRGB(uint DMXChannel, int dimmerChannel, out float intensity)
+{
+    int startChannel = (int)DMXChannel + (dimmerChannel-1);
+    intensity = getValueAtCoords(startChannel, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+    return GetDMXRGB((uint) startChannel, intensity, 0);
+}
+
+#if _1CH_MODE
+    float4 GetDMXEmission1CH(float2 EmissionUV)
+    {
+        uint dmx = getDMXChannel();
+        float dmxIntensity = IF(isDMX()==1, getValueAtCoords(dmx, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture)), 1.0);
+        float4 DMXcol = getEmissionColor() * dmxIntensity;
+        float4 col = IF(isDMX() == 1, DMXcol * (_CurveMod), getEmissionColor());
+        float4 e = col;
+        #ifndef LENS_FLARE
+            e *= SAMPLE_TEXTURE2D(_EmissionMask, sampler_EmissionMask, EmissionUV).r;
+        #endif
+        float sat = (e.r + e.g + e.b)/3.0;
+        e.rgb = lerp(float3(sat,sat,sat), e, _Saturation);
+        e = ((e * _FixtureMaxIntensity) * getGlobalIntensity()) * getFinalIntensity();
+        e *= _UniversalIntensity;
+        return lerp(float4(0,0,0,0),e, dmxIntensity) * (lerp(1,_CurveMod, dmxIntensity)) * getEmissionColor();
+    }
+#endif
+
+#if _4CH_MODE
+    float4 GetDMXEmission4CH(float2 EmissionUV)
+    {
+        uint dmx = getDMXChannel();
+        float dmxIntensity = IF(isDMX()==1, getValueAtCoords(dmx, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture)), 1.0);
+        float4 DMXcol = GetDMXRGB(dmx, dmxIntensity,0) * getEmissionColor();
+        float4 col = IF(isDMX() == 1, DMXcol * (_CurveMod), getEmissionColor());
+        float4 e = col;
+        #ifndef LENS_FLARE
+            e *= SAMPLE_TEXTURE2D(_EmissionMask, sampler_EmissionMask, EmissionUV).r;
+        #endif
+        float sat = (e.r + e.g + e.b)/3.0;
+        e.rgb = lerp(float3(sat,sat,sat), e, _Saturation);
+        e = ((e * _FixtureMaxIntensity) * getGlobalIntensity()) * getFinalIntensity();
+        e *= _UniversalIntensity;
+        return lerp(float4(0,0,0,0),e, dmxIntensity) * (lerp(1,_CurveMod, dmxIntensity)) * getEmissionColor();
+    }
+#endif
+
+#if _5CH_MODE
+    float4 GetDMXEmission5CH(float2 EmissionUV)
+    {
+        uint dmx = getDMXChannel();
+        float dmxIntensity = IF(isDMX()==1, getValueAtCoords(dmx, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture)), 1.0);
+        float strobe = IF(isStrobe() == 1, GetSurfaceStrobe(dmx), 1);
+        float4 DMXcol = GetDMXRGB(dmx, dmxIntensity,0) * getEmissionColor();
+        float4 col = IF(isDMX() == 1, DMXcol * (_CurveMod), getEmissionColor());
+        float4 e = col * strobe;
+        #ifndef LENS_FLARE
+            e *= SAMPLE_TEXTURE2D(_EmissionMask, sampler_EmissionMask, EmissionUV).r;
+        #endif
+        float sat = (e.r + e.g + e.b)/3.0;
+        e.rgb = lerp(float3(sat,sat,sat), e, _Saturation);
+        e = ((e * _FixtureMaxIntensity) * getGlobalIntensity()) * getFinalIntensity();
+        e *= _UniversalIntensity;
+        return lerp(float4(0,0,0,0),e, dmxIntensity) * (lerp(1,_CurveMod, dmxIntensity)) * getEmissionColor();
+    }
+#endif
+
+#if _13CH_MODE
+    float4 GetDMXEmission13CH(float2 EmissionUV)
+    {
+        uint dmx = getDMXChannel();
+        float dmxIntensity = IF(isDMX()==1, getValueAtCoords(dmx+5, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture)), 1.0);
+        float strobe = IF(isStrobe() == 1, GetSurfaceStrobe(dmx+2), 1);
+        float4 DMXcol = GetDMXRGB(dmx, dmxIntensity,6) * getEmissionColor();
+        float4 col = IF(isDMX() == 1, DMXcol * (_CurveMod), getEmissionColor());
+        float4 e = col * strobe;
+        #ifndef LENS_FLARE
+            e *= SAMPLE_TEXTURE2D(_EmissionMask, sampler_EmissionMask, EmissionUV).r;
+        #endif
+        float sat = (e.r + e.g + e.b)/3.0;
+        e.rgb = lerp(float3(sat,sat,sat), e, _Saturation);
+        e = ((e * _FixtureMaxIntensity) * getGlobalIntensity()) * getFinalIntensity();
+        e *= _UniversalIntensity;
+        return lerp(float4(0,0,0,0),e, dmxIntensity) * (lerp(1,_CurveMod, dmxIntensity)) * getEmissionColor();
+    }
+#endif
+
+int GetCurrent12CH(float2 uv)
+{
+    if(uv.y > 0.22 && uv.y < 0.3)
+    {
+        if(uv.x > 0.027581 && uv.x < 0.079706)
+        {
+            #ifndef _CHANNEL_MODE
+            return 1;
+            #else
+            return 1;
+            #endif
+        }
+        else if(uv.x > 0.119042 && uv.x < 0.150821)
+        {
+            #ifndef _CHANNEL_MODE
+            return 2;
+            #else
+            return 5;
+            #endif
+        }
+        else if(uv.x > 0.19694 && uv.x < 0.237864)
+        {
+            #ifndef _CHANNEL_MODE
+            return 3;
+            #else
+            return 9;
+            #endif
+        }
+        else if(uv.x > 0.27888 && uv.x < 0.318998)
+        {
+            #ifndef _CHANNEL_MODE
+            return 4;
+            #else
+            return 13;
+            #endif
+        }
+        else if(uv.x > 0.354643 && uv.x < 0.407866)
+        {
+            #ifndef _CHANNEL_MODE
+            return 5;
+            #else
+            return 17;
+            #endif
+        }
+        else if(uv.x > 0.441313 && uv.x < 0.470366)
+        {
+            #ifndef _CHANNEL_MODE
+            return 6;
+            #else
+            return 21;
+            #endif
+        }
+        else if(uv.x > 0.522612 && uv.x < 0.559965)
+        {
+            #ifndef _CHANNEL_MODE
+            return 7;
+            #else
+            return 25;
+            #endif
+        }
+        else if(uv.x > 0.60 && uv.x < 0.68)
+        {
+            #ifndef _CHANNEL_MODE
+            return 8;
+            #else
+            return 29;
+            #endif
+        }
+        else if(uv.x > 0.69 && uv.x < 0.75)
+        {
+            #ifndef _CHANNEL_MODE
+            return 9;
+            #else
+            return 33;
+            #endif
+        }
+        else if(uv.x > 0.76 && uv.x < 0.80)
+        {
+            #ifndef _CHANNEL_MODE
+            return 10;
+            #else
+            return 37;
+            #endif
+        }
+        else if(uv.x > 0.81 && uv.x < 0.92)
+        {
+            #ifndef _CHANNEL_MODE
+            return 11;
+            #else
+            return 41;
+            #endif
+        }
+        else
+        {
+            #ifndef _CHANNEL_MODE
+            return 12;
+            #else
+            return 45;
+            #endif
+        }
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+float4 GetDMXEmission12Ch(float2 EmissionUV)
+{
+    uint dmx = getDMXChannel();
+    #ifndef _CHANNEL_MODE
+        float dmxIntensity = GetDMX12CH(dmx, GetCurrent12CH(EmissionUV));  
+        float4 DMXcol = GetDMXRGB(dmx-1, dmxIntensity,0) * getEmissionColor();
+    #else
+        float dmxIntensity = 0.0;
+        float4 DMXcol = GetDMX12CHRGB(dmx, GetCurrent12CH(EmissionUV), dmxIntensity) * getEmissionColor();
+    #endif
+    
+    float4 col = IF(isDMX() == 1, DMXcol * _CurveMod, getEmissionColor());
+    half4 e = col;
+    
+    #ifndef LENS_FLARE
+        e *= SAMPLE_TEXTURE2D(_EmissionMask, sampler_EmissionMask, EmissionUV).r;
+    #endif
+    
+    float sat = (e.r + e.g + e.b)/3.0;
+    e.rgb = lerp(float3(sat,sat,sat), e, _Saturation);
+    e = ((e * _FixtureMaxIntensity) * getGlobalIntensity()) * getFinalIntensity();
+    e *= _UniversalIntensity;
+    dmxIntensity = dmxIntensity * dmxIntensity * dmxIntensity * dmxIntensity;
+    return lerp(float4(0,0,0,0),e, dmxIntensity) * (lerp(1,_CurveMod, dmxIntensity));
+}
+
+#ifdef SURF_ALPHA
+float GetDMXAlpha()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _EnableDMXAlpha) == 1 && isDMX() == 1 ? 
+        getValueAtCoords((getDMXChannel() + 5), TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture)) : 1.0;
+}
+#endif
+
+#endif
+#endif

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Functions-URP.hlsl.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Functions-URP.hlsl.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5d24bc959796484ba27cd22bdd480996
+timeCreated: 1746558638

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Opaque 12 Channel Bar.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Opaque 12 Channel Bar.shader
@@ -78,6 +78,9 @@
                 float3 normalOS : NORMAL;
                 float4 tangentOS : TANGENT;
                 float2 uv : TEXCOORD0;
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                #endif
             };
 
             struct Varyings
@@ -87,6 +90,10 @@
                 float3 normalWS : TEXCOORD1;
                 float3 positionWS : TEXCOORD2;
                 float4 tangentWS : TEXCOORD3;
+                #if UNIVERSAL_RENDER_PIPELINE
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+                #endif
             };
 
             #if defined(UNIVERSAL_RENDER_PIPELINE)
@@ -105,6 +112,9 @@
                 Varyings output = (Varyings)0;
 
                 #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+                UNITY_TRANSFER_INSTANCE_ID(input, output);
                 // Positions
                 VertexPositionInputs posInputs = GetVertexPositionInputs(input.positionOS.xyz);
                 output.positionHCS = posInputs.positionCS;
@@ -128,6 +138,8 @@
             half4 frag(Varyings input) : SV_Target
             {
                 #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(iinput);
                 // Sample textures
                 half4 baseMap = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
                 half4 metallicSmoothness = SAMPLE_TEXTURE2D(_MetallicSmoothness, sampler_MetallicSmoothness, input.uv);

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Opaque.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Opaque.shader
@@ -38,6 +38,356 @@
         [Enum(1CH,0,4CH,1,5CH,2,13CH,3)] _ChannelMode ("Channel Mode", Int) = 2
 
     }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Opaque"
+            "RenderPipeline" = "UniversalPipeline"
+        }
+        LOD 100
+
+        // Forward Pass
+        Pass
+        {
+            Name "ForwardLit"
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #define VRSL_DMX
+            #define VRSL_SURFACE
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma shader_feature _ _1CH_MODE _4CH_MODE _5CH_MODE _13CH_MODE
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS_CASCADE
+            #pragma multi_compile _ _SHADOWS_SOFT
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+
+            #include "../Shared/VRSL-Defines-URP.hlsl"
+            #include "../Shared/VRSL-DMXFunctions-URP.hlsl"
+            #include "VRSL-StandardSurface-Functions-URP.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float4 tangentOS : TANGENT;
+                float2 uv : TEXCOORD0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                #endif
+            };
+
+            struct Varyings
+            {
+                float4 positionHCS : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normalWS : TEXCOORD1;
+                float3 positionWS : TEXCOORD2;
+                float4 tangentWS : TEXCOORD3;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+                #endif
+            };
+
+            Varyings vert(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                // Positions
+                VertexPositionInputs posInputs = GetVertexPositionInputs(input.positionOS.xyz);
+                output.positionHCS = posInputs.positionCS;
+                output.positionWS = posInputs.positionWS;
+
+                // Normals and tangents
+                VertexNormalInputs normalInputs = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+                output.normalWS = normalInputs.normalWS;
+
+                // Calculate tangent for normal mapping
+                real sign = input.tangentOS.w * GetOddNegativeScale();
+                output.tangentWS = float4(normalInputs.tangentWS.xyz, sign);
+
+                // UVs
+                output.uv = TRANSFORM_TEX(input.uv, _MainTex);
+                #endif
+                return output;
+            }
+
+            half4 frag(Varyings input) : SV_Target
+            {
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                // Sample textures
+                half4 baseMap = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
+                half4 metallicSmoothness = SAMPLE_TEXTURE2D(_MetallicSmoothness, sampler_MetallicSmoothness, input.uv);
+                half4 color = baseMap * _Color;
+
+                // Calculate tangent space to world space matrix
+                float3 normalTS = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv));
+
+                float3 normalWS;
+                float3 tangentWS = normalize(input.tangentWS.xyz);
+                float3 bitangentWS = normalize(cross(input.normalWS, tangentWS) * input.tangentWS.w);
+
+                // Transform normal from tangent to world space
+                float3x3 tangentToWorld = float3x3(tangentWS, bitangentWS, input.normalWS);
+                normalWS = normalize(mul(normalTS, tangentToWorld));
+
+                // Surface data
+                InputData lightingInput = (InputData)0;
+                lightingInput.normalWS = normalWS;
+                lightingInput.positionWS = input.positionWS;
+                lightingInput.viewDirectionWS = GetWorldSpaceNormalizeViewDir(input.positionWS);
+                lightingInput.shadowCoord = TransformWorldToShadowCoord(input.positionWS);
+
+                SurfaceData surfaceData = (SurfaceData)0;
+                surfaceData.albedo = color.rgb;
+                surfaceData.alpha = color.a;
+
+                // Metallic in R channel, Smoothness in A channel (standard convention)
+                surfaceData.metallic = metallicSmoothness.r * _Metallic;
+                surfaceData.smoothness = metallicSmoothness.r * _Glossiness;
+
+                // Albedo comes from a texture tinted by color
+                float2 emUV = TRANSFORM_TEX(input.uv, _EmissionMask);
+                #if _1CH_MODE
+                    surfaceData.emission = GetDMXEmission1CH(emUV) * _CurveMod;
+                #elif _4CH_MODE
+                    surfaceData.emission = GetDMXEmission4CH(emUV) * _CurveMod;
+                #elif _5CH_MODE
+                    surfaceData.emission = GetDMXEmission5CH(emUV) * _CurveMod;
+                #elif _13CH_MODE
+                    surfaceData.emission = GetDMXEmission13CH(emUV) * _CurveMod;
+                #endif
+
+                surfaceData.normalTS = normalTS;
+
+                // Apply lighting
+                return UniversalFragmentPBR(lightingInput, surfaceData);
+                #else
+                return (0).xxxx;
+                #endif
+            }
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags
+            {
+                "LightMode" = "ShadowCaster"
+            }
+
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex ShadowPassVertex
+            #pragma fragment ShadowPassFragment
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl"
+
+            #include "../Shared/VRSL-Defines-URP.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+            };
+
+            float3 _LightDirection;
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            float4 GetShadowPositionHClip(Attributes input)
+            {
+                float3 positionWS = TransformObjectToWorld(input.positionOS.xyz);
+                float3 normalWS = TransformObjectToWorldNormal(input.normalOS);
+
+                float4 positionCS = TransformWorldToHClip(ApplyShadowBias(positionWS, normalWS, _LightDirection));
+
+                #if UNITY_REVERSED_Z
+                positionCS.z = min(positionCS.z, positionCS.w * UNITY_NEAR_CLIP_VALUE);
+                #else
+                    positionCS.z = max(positionCS.z, positionCS.w * UNITY_NEAR_CLIP_VALUE);
+                #endif
+
+                return positionCS;
+            }
+            #endif
+
+            Varyings ShadowPassVertex(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                output.positionCS = GetShadowPositionHClip(input);
+                #endif
+                return output;
+            }
+
+            half4 ShadowPassFragment(Varyings input) : SV_TARGET
+            {
+                return 0;
+            }
+            ENDHLSL
+        }
+
+        // DepthOnly Pass, Required for depth priming
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            ZWrite On
+            ColorMask 0
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex DepthOnlyVertex
+            #pragma fragment DepthOnlyFragment
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            #include "../Shared/VRSL-Defines-URP.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                float4 position : POSITION;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+            };
+
+            Varyings DepthOnlyVertex(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                output.positionCS = TransformObjectToHClip(input.position.xyz);
+                #endif
+                return output;
+            }
+
+            half4 DepthOnlyFragment(Varyings input) : SV_TARGET
+            {
+                return 0;
+            }
+            ENDHLSL
+        }
+
+        // DepthNormals Pass, Required for depth priming
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            ZWrite On
+
+            HLSLPROGRAM
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #pragma vertex DepthNormalsVertex
+            #pragma fragment DepthNormalsFragment
+
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            #include "../Shared/VRSL-Defines-URP.hlsl"
+
+            TEXTURE2D(_NormalMap);
+            SAMPLER(sampler_NormalMap);
+            #endif
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float4 tangentOS : TANGENT;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 normalWS : TEXCOORD1;
+                float4 tangentWS : TEXCOORD2;
+            };
+
+            Varyings DepthNormalsVertex(Attributes input)
+            {
+                Varyings output = (Varyings)0;
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                output.positionCS = TransformObjectToHClip(input.positionOS.xyz);
+                output.uv = TRANSFORM_TEX(input.texcoord, _MainTex);
+
+                VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+                output.normalWS = normalInput.normalWS;
+
+                real sign = input.tangentOS.w * GetOddNegativeScale();
+                output.tangentWS = float4(normalInput.tangentWS.xyz, sign);
+                #endif
+                return output;
+            }
+
+            half4 DepthNormalsFragment(Varyings input) : SV_TARGET
+            {
+                #if defined(UNIVERSAL_RENDER_PIPELINE)
+                // Read normal map
+                float3 normalTS = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv));
+
+                // Calculate tangent space to world space matrix
+                float3 tangentWS = normalize(input.tangentWS.xyz);
+                float3 bitangentWS = normalize(cross(input.normalWS, tangentWS) * input.tangentWS.w);
+
+                // Transform normal from tangent to world space
+                float3x3 tangentToWorld = float3x3(tangentWS, bitangentWS, input.normalWS);
+                float3 normalWS = normalize(mul(normalTS, tangentToWorld));
+
+                // Convert normal from [-1,1] to [0,1] range
+                float3 normalViewSpace = TransformWorldToViewDir(normalWS) * 0.5 + 0.5;
+
+                return half4(normalViewSpace, 0);
+                #else
+                return (0).xxxx;
+                #endif
+            }
+            ENDHLSL
+        }
+    }
+
     SubShader
     {
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Opaque.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Basic Surface Shaders/VRSL-StandardSurface-Opaque.shader
@@ -106,6 +106,9 @@
             {
                 Varyings output = (Varyings)0;
                 #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+                UNITY_TRANSFER_INSTANCE_ID(input, output);
                 // Positions
                 VertexPositionInputs posInputs = GetVertexPositionInputs(input.positionOS.xyz);
                 output.positionHCS = posInputs.positionCS;
@@ -128,6 +131,8 @@
             half4 frag(Varyings input) : SV_Target
             {
                 #if defined(UNIVERSAL_RENDER_PIPELINE)
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
                 // Sample textures
                 half4 baseMap = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
                 half4 metallicSmoothness = SAMPLE_TEXTURE2D(_MetallicSmoothness, sampler_MetallicSmoothness, input.uv);

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Discoball/VRSL-Discoball.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Discoball/VRSL-Discoball.shader
@@ -28,6 +28,170 @@
      }
      SubShader
      {
+         Tags { "Queue" = "Transparent+1"
+             "ForceNoShadowCasting"="True"
+             "IgnoreProjector"="True"
+             "RenderType" = "Transparent"
+             "RenderingPipeline"="UniversalPipeline"
+         }
+         Offset -1, -5
+         Stencil
+         {
+            Ref 142
+            Comp NotEqual
+            Pass Keep
+         }
+
+         Pass
+         {
+            AlphaToMask [_AlphaToCoverage]
+            Cull Front
+            Ztest Greater
+            ZWrite  Off
+            Blend DstColor [_BlendDst]
+            Lighting Off
+		    SeparateSpecular Off
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #define VRSL_DMX
+            uniform samplerCUBE _Cube;
+            float4 _Cube_ST;
+            float _RotationSpeed;
+            #include "UnityCG.cginc"
+             struct appdata
+             {
+                 float4 vertex : POSITION;
+                 float2 uv : TEXCOORD0;
+                 float3 texcoord : TEXCOORD1;
+             };
+             struct v2f
+             {
+                 float4 vertex : SV_POSITION;
+                 float2 uv : TEXCOORD0;
+                 float3 ray : TEXCOORD2;
+                 float4 screenPos : TEXCOORD4;
+                 float4 worldDirection : TEXCOORD5;
+                 float4 worldPos : TEXCOORD6;
+                 float2 dmxIntensity: TEXCOORD7;
+                 UNITY_VERTEX_OUTPUT_STEREO
+             };
+            #include "../Shared/VRSL-Defines.cginc"
+            half _Multiplier;
+			#include "../Shared/VRSL-DMXFunctions.cginc"
+
+             float4 Rotation(float4 vertPos)
+             {
+	            //CALCULATE BASE ROTATION. MORE FUN MATH. THIS IS FOR PAN.
+                float angleY = radians(_Time.y * _RotationSpeed);
+                float c = cos(angleY);
+                float s = sin(angleY);
+                float4x4 rotateYMatrix = float4x4(c, 0, s, 0,
+                    0, 1, 0, 0,
+                    -s, 0, c, 0,
+                    0, 0, 0, 1);
+                return mul(rotateYMatrix, vertPos);
+             }
+
+             inline float4 CalculateFrustumCorrection()
+             {
+                 float x1 = -UNITY_MATRIX_P._31/(UNITY_MATRIX_P._11*UNITY_MATRIX_P._34);
+                 float x2 = -UNITY_MATRIX_P._32/(UNITY_MATRIX_P._22*UNITY_MATRIX_P._34);
+                 return float4(x1, x2, 0, UNITY_MATRIX_P._33/UNITY_MATRIX_P._34 + x1*UNITY_MATRIX_P._13 + x2*UNITY_MATRIX_P._23);
+             }
+
+             //CREDIT TO DJ LUKIS FOR MIRROR DEPTH CORRECTION
+             inline float CorrectedLinearEyeDepth(float z, float B)
+             {
+                 return 1.0 / (z/UNITY_MATRIX_P._34 + B);
+             }
+
+             v2f vert(appdata v)
+             {
+                v2f o;
+                UNITY_INITIALIZE_OUTPUT(v2f, o); //DON'T INITIALIZE OR IT WILL BREAK PROJECTION
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+               // UNITY_TRANSFER_INSTANCE_ID(v, o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.ray = UnityObjectToViewPos(v.vertex).xyz;
+                o.ray = o.ray.xyz * float3(-1,-1,1);
+                o.ray = lerp(o.ray, v.texcoord, v.texcoord.z != 0);
+                o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+                o.screenPos = ComputeScreenPos(o.vertex);
+                o.worldDirection.xyz = o.worldPos.xyz - _WorldSpaceCameraPos;
+                // pack correction factor into direction w component to save space
+                o.worldDirection.w = dot(o.vertex, CalculateFrustumCorrection());
+                uint dmx = getDMXChannel();
+                o.dmxIntensity = IF(_EnableCompatibilityMode == 1, float2(dmx, getValueAtCoords(dmx, _Udon_DMXGridRenderTexture)), float2(dmx, getValueAtCoords(dmx, _Udon_DMXGridRenderTexture)));
+                if(o.dmxIntensity.y <= 0.05 && _EnableDMX == 1)
+                {
+                    v.vertex = float4(0,0,0,0);
+                    o.vertex = UnityObjectToClipPos(v.vertex);
+
+                }
+                return o;
+             }
+
+             #define IF(a, b, c) lerp(b, c, step((fixed) (a), 0));
+
+             fixed4 frag(v2f i) : SV_Target
+             {
+                 if(i.dmxIntensity.y <= 0.05 && _EnableDMX == 1)
+                 {
+                     return half4(0,0,0,0);
+                 }
+                 #if _ALPHATEST_ON
+                     float2 pos = i.screenPos.xy / i.screenPos.w;
+                     pos *= _ScreenParams.xy;
+                     float DITHER_THRESHOLDS[16] =
+                     {
+                         1.0 / 17.0,  9.0 / 17.0,  3.0 / 17.0, 11.0 / 17.0,
+                         13.0 / 17.0,  5.0 / 17.0, 15.0 / 17.0,  7.0 / 17.0,
+                         4.0 / 17.0, 12.0 / 17.0,  2.0 / 17.0, 10.0 / 17.0,
+                         16.0 / 17.0,  8.0 / 17.0, 14.0 / 17.0,  6.0 / 17.0
+                     };
+                     int index = (int)((uint(pos.x) % 4) * 4 + uint(pos.y) % 4);
+		         #endif
+                 float4 depthdirect = i.worldDirection * (1.0f / i.vertex.w);
+                 float sceneZ = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i.screenPos.xy / i.screenPos.w);
+                 #if UNITY_REVERSED_Z
+                     if (sceneZ == 0)
+                 #else
+                     if (sceneZ == 1)
+                 #endif
+                         return half4(0,0,0,0);
+
+                 float depth = CorrectedLinearEyeDepth(sceneZ, depthdirect.w);
+                 i.ray = i.ray * (_ProjectionParams.z / i.ray.z);
+                 depth = Linear01Depth((1.0 - (depth * _ZBufferParams.w)) / (depth * _ZBufferParams.z));
+                 float3 wpos = mul(unity_CameraToWorld, float4(i.ray * depth, 1)).xyz;
+                 float UVscale = pow(abs(distance( mul(unity_ObjectToWorld, float4(0.0,0.0,0.0,1.0) ).xyz,wpos)),-1);
+                 float3 projPos = (mul(unity_WorldToObject,float4(wpos, 1)));
+                 if(0.0 < abs(projPos.x) < 0.1)
+                 {
+                     return half4(0,0,0,0);
+                 }
+                 projPos = Rotation(float4(projPos, 0)).xyz;
+                 float4 col = (texCUBE (_Cube, projPos));
+                 col = col *(_Emission * (4*UVscale));
+                 col = IF(_EnableDMX == 1, col * i.dmxIntensity.y, col);
+                 col = (col * _Multiplier)*((col * getGlobalIntensity()) * getFinalIntensity());
+                 col = col * _UniversalIntensity;
+
+                 #ifdef _ALPHATEST_ON
+                     clip(col.a - DITHER_THRESHOLDS[index]);
+                     clip((((col.r + col.g + col.b)/3) * (_ClippingThreshold)) - DITHER_THRESHOLDS[index]);
+                     return col;
+                 #else
+                         return col;
+                 #endif
+             }
+             ENDCG
+         }//end color pass
+     }
+     SubShader
+     {
          Tags{ "Queue" = "Transparent+1" "ForceNoShadowCasting"="True" "IgnoreProjector"="True" "RenderType" = "Transparent" }
          Offset -1, -5
         	Stencil

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-BasicLaser-DMX.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-BasicLaser-DMX.shader
@@ -39,6 +39,341 @@
     }
     SubShader
     {
+		Tags { "RenderType"="Transparent" "Queue" = "Transparent+1" "RenderingPipeline" = "UniversalPipeline" }
+		Cull Off
+		Blend One One
+		Zwrite Off
+		LOD 100
+
+        Pass
+        {
+            Stencil
+			{
+				Ref 142
+				Comp NotEqual
+				Pass Keep
+			}
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            // make fog work
+            //#pragma multi_compile_fog
+            #pragma multi_compile_instancing
+
+            #include "UnityCG.cginc"
+            #define LASER
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float2 uv : TEXCOORD0;
+                float2 uv2 : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+               centroid float2 uv : TEXCOORD0;
+               centroid float2 uv2 : TEXCOORD1;
+                float3 normal : TEXCOORD2;
+                UNITY_FOG_COORDS(1)
+                float4 vertex : SV_POSITION;
+                float4 worldPos : TEXCOORD3;
+                float3 viewDir : TEXCOORD4;
+                nointerpolation float4 panTiltLengthWidth : TEXCOORD5; //ch 1,2,3,4
+                nointerpolation float4 flatnessBeamCountSpinThickness : TEXCOORD6; //ch 5,6,7,12
+                nointerpolation float4 rgbIntensity : TEXCOORD7;// ch 8,9,10,11
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST, _MainColor;
+            half _XConeFlatness, _ZRotation, _UniversalIntensity;
+            half _EndFade, _FadeStrength, _InternalShine, _LaserSoftening, _InternalShineLength;
+            float _ScrollOffset;
+            uint _EnableCompatibilityMode, _EnableVerticalMode;
+            sampler2D _Udon_DMXGridRenderTexture, _Udon_DMXGridRenderTextureMovement, _Udon_DMXGridSpinTimer;
+            uniform float4 _Udon_DMXGridRenderTexture_TexelSize;
+            uniform const half compatSampleYAxis = 0.019231;
+            uniform const half standardSampleYAxis = 0.00762;
+
+            UNITY_INSTANCING_BUFFER_START(Props)
+                UNITY_DEFINE_INSTANCED_PROP(uint, _DMXChannel)
+                UNITY_DEFINE_INSTANCED_PROP(uint, _NineUniverseMode)
+                UNITY_DEFINE_INSTANCED_PROP(uint, _EnableColorTextureSample)
+                UNITY_DEFINE_INSTANCED_PROP(uint, _LaserCount)
+                UNITY_DEFINE_INSTANCED_PROP(uint, _EnableDMX)
+                UNITY_DEFINE_INSTANCED_PROP(half, _Scroll)
+                UNITY_DEFINE_INSTANCED_PROP(half, _XRotation)
+                UNITY_DEFINE_INSTANCED_PROP(half, _YRotation)
+                UNITY_DEFINE_INSTANCED_PROP(half, _LaserThickness)
+                UNITY_DEFINE_INSTANCED_PROP(half4, _Emission)
+                UNITY_DEFINE_INSTANCED_PROP(half, _ZConeFlatness)
+                UNITY_DEFINE_INSTANCED_PROP(half, _VertexConeWidth)
+                UNITY_DEFINE_INSTANCED_PROP(half, _VertexConeLength)
+                UNITY_DEFINE_INSTANCED_PROP(half, _GlobalIntensity)
+                UNITY_DEFINE_INSTANCED_PROP(half, _GlobalIntensityBlend)
+                UNITY_DEFINE_INSTANCED_PROP(half, _FinalIntensity)
+                UNITY_DEFINE_INSTANCED_PROP(half, _TextureColorSampleX)
+                UNITY_DEFINE_INSTANCED_PROP(half, _TextureColorSampleY)
+            UNITY_INSTANCING_BUFFER_END(Props)
+
+            #include "../Shared/VRSL-DMXFunctions.cginc"
+
+            //#define IF(a, b, c) lerp(b, c, step((fixed) (a), 0));
+
+            half getPan()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props,_XRotation);
+            }
+            half getTilt()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props,_YRotation);
+            }
+            uint getLaserCount()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props,_LaserCount);
+            }
+            half getConeWidth()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props,_VertexConeWidth);
+            }
+            half getConeLength()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props,_VertexConeLength);
+            }
+            half getLaserThickness()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props,_LaserThickness);
+            }
+            half getScrollSpeed()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props,_Scroll);
+            }
+            half getConeFlatness()
+            {
+                return UNITY_ACCESS_INSTANCED_PROP(Props, _ZConeFlatness);
+            }
+
+            half3 RGB2HSV(half3 c)
+            {
+                half4 K = half4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                half4 p = lerp(half4(c.bg, K.wz), half4(c.gb, K.xy), step(c.b, c.g));
+                half4 q = lerp(half4(p.xyw, c.r), half4(c.r, p.yzx), step(p.x, c.r));
+
+                half d = q.x - min(q.w, q.y);
+                half e = 1.0e-10;
+                return half3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            half3 hsb2rgb( half3 c ){
+                half3 rgb = clamp( abs(fmod(c.x*6.0+half3(0.0,4.0,2.0),6)-3.0)-1.0, 0, 1);
+                rgb = rgb*rgb*(3.0-2.0*rgb);
+                return c.z * lerp( half3(1,1,1), rgb, c.y);
+            }
+
+            half4 CalculateRotations(appdata v, half4 input, half pan, half tilt, half roll)
+            {
+                half angleY = radians(pan);
+                half c = cos(angleY);
+                half s = sin(angleY);
+                half4x4 rotateYMatrix = half4x4(c, -s, 0, 0,
+                    s, c, 0, 0,
+                    0, 0, 1, 0,
+                    0, 0, 0, 1);
+                half4 BaseAndFixturePos = input;
+                half4 localRotY = mul(rotateYMatrix, BaseAndFixturePos);
+
+                half angleX = radians(tilt);
+                c = cos(angleX);
+                s = sin(angleX);
+                half4x4 rotateXMatrix = half4x4(1, 0, 0, 0,
+                    0, c, -s, 0,
+                    0, s, c, 0,
+                    0, 0, 0, 1);
+
+                half4x4 rotateXYMatrix = mul(rotateYMatrix, rotateXMatrix);
+                //half4 localRotXY = mul(rotateXYMatrix, input);
+
+                half angleZ = radians(roll);
+                c = cos(angleZ);
+                s = sin(angleZ);
+                half4x4 rotateZMatrix = half4x4(c, 0, s, 0,
+                    0, 1, 0, 0,
+                    -s, 0, c, 0,
+                    0, 0, 0, 1);
+                half4x4 rotateXYZMatrix = mul(rotateZMatrix, rotateXYMatrix);
+                half4 localRotXYZ = mul(rotateXYZMatrix, input);
+                input.xyz = localRotXYZ.xyz;
+                return input;
+                //LOCALROTXY IS COMBINED ROTATION
+            }
+
+            half GetSpin(uint DMXChannel)
+            {
+                half status = getValueAtCoords(DMXChannel, _Udon_DMXGridRenderTexture);
+                half phase = getValueAtCoordsRaw(DMXChannel, _Udon_DMXGridSpinTimer);
+                //phase = checkPanInvertY() == 1 ? -phase : phase;
+                return status > 0.5 ? -phase : phase;
+            }
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_OUTPUT(v2f, o)
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+
+                uint dmx = getDMXChannel();
+                o.rgbIntensity.w = getValueAtCoords(dmx + (uint) 10, _Udon_DMXGridRenderTexture);
+                o.rgbIntensity.w = IF(isDMX() > 0, o.rgbIntensity.w, 1);
+                if(getGlobalIntensity() <= 0.01 || getFinalIntensity() <= 0.05 || _UniversalIntensity <= 0.05 || o.rgbIntensity.w <= 0.05)
+                {
+                    o.vertex = UnityObjectToClipPos(half4(0,0,0,0));
+                    return o;
+                }
+                o.panTiltLengthWidth.x = lerp(-90,90,clamp(getValueAtCoords(dmx, _Udon_DMXGridRenderTextureMovement), 0.0,0.9999)); // ch 1
+                o.panTiltLengthWidth.y = lerp(-90,90,clamp(getValueAtCoords(dmx + (uint) 1, _Udon_DMXGridRenderTextureMovement), 0.0,0.9999)); // ch 2
+                o.panTiltLengthWidth.z = lerp(-0.5,5,clamp(getValueAtCoords(dmx + (uint) 2, _Udon_DMXGridRenderTexture), 0.0,0.9999)); // ch 3
+                o.panTiltLengthWidth.w = lerp(-3.75,20,clamp(getValueAtCoords(dmx + (uint) 3, _Udon_DMXGridRenderTexture), 0.0,0.9999)); // ch 4
+
+                //replacement for _WorldSpaceCameraPos
+                float3 wpos;
+                wpos.x = unity_CameraToWorld[0][3];
+                wpos.y = unity_CameraToWorld[1][3];
+                wpos.z = unity_CameraToWorld[2][3];
+
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                o.uv2 = TRANSFORM_TEX(v.uv2, _MainTex);
+
+                //Cone Length
+                half length = IF(isDMX() > 0, o.panTiltLengthWidth.z, getConeLength());
+                v.vertex.y = lerp(v.vertex.y, v.vertex.y *2, length);
+
+                //Cone Width
+                half width = IF(isDMX() > 0, o.panTiltLengthWidth.w, getConeWidth());
+                half4 vert = lerp(v.vertex ,half4(v.vertex.xyz + v.normal * width, 1), v.uv2.y);
+                vert.y = v.vertex.y; //Prevent the cone from elongating when changing width.
+
+                // Cone Flatness for X and Z
+                half flatness = lerp(0,1.999,getValueAtCoords(dmx+ (uint) 4, _Udon_DMXGridRenderTexture));
+                flatness = IF(isDMX() > 0, flatness, getConeFlatness());
+                vert.z = lerp(vert.z, vert.z/2, flatness);
+              //  vert.x = lerp(vert.x, vert.x/2, _XConeFlatness);
+                half xRot = IF(isDMX() > 0, o.panTiltLengthWidth.x, getPan());
+                half yRot = IF(isDMX() > 0, o.panTiltLengthWidth.y, getTilt());
+                vert = CalculateRotations(v, vert, _ZRotation, xRot, yRot);
+
+                o.viewDir = normalize(wpos - mul(unity_ObjectToWorld, vert).xyz);
+                v.normal = CalculateRotations(v, half4(v.normal, 1), _ZRotation, xRot, yRot).xyz;
+                o.normal = normalize(mul(half4(v.normal, 0.0), unity_WorldToObject).xyz);
+                o.worldPos = mul(unity_ObjectToWorld, vert);
+                o.vertex = UnityObjectToClipPos(vert);
+
+                o.flatnessBeamCountSpinThickness.x = lerp(0,1.999,getValueAtCoords(dmx+ (uint) 4, _Udon_DMXGridRenderTexture)); //5
+                o.flatnessBeamCountSpinThickness.y = lerp(4,68,getValueAtCoords(dmx+ (uint) 5, _Udon_DMXGridRenderTexture));//6
+                o.flatnessBeamCountSpinThickness.z = GetSpin(dmx+ (uint) 6) * _ScrollOffset; //7
+                o.flatnessBeamCountSpinThickness.w = lerp(0.0005, 0.05,getValueAtCoords(dmx+ (uint) 11, _Udon_DMXGridRenderTexture)); //12
+                o.rgbIntensity.x = getValueAtCoords(dmx+ (uint) 7, _Udon_DMXGridRenderTexture); //8 
+                o.rgbIntensity.y = getValueAtCoords(dmx+ (uint) 8, _Udon_DMXGridRenderTexture); //9
+                o.rgbIntensity.z = getValueAtCoords(dmx+ (uint) 9, _Udon_DMXGridRenderTexture); //10
+                o.rgbIntensity.w = getValueAtCoords(dmx+ (uint) 10, _Udon_DMXGridRenderTexture); //11
+
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+                UNITY_SETUP_INSTANCE_ID(i);
+                uint dmx = getDMXChannel();
+
+                i.rgbIntensity.w = IF(isDMX() > 0, i.rgbIntensity.w, 1);
+                if(getGlobalIntensity() <= 0.001 || getFinalIntensity() <= 0.001 || _UniversalIntensity <= 0.001 || i.rgbIntensity.w <= 0.001)
+                {
+                    return half4(0,0,0,0);
+                }
+                half fade = pow(saturate(dot(normalize(i.normal), i.viewDir)), _FadeStrength);
+
+                // fade = pow(fade, pow(_FadeStrength, _FadeAmt)) * fade;
+                // sample the texture
+                half4 dmxcol = half4(i.rgbIntensity.x,i.rgbIntensity.y, i.rgbIntensity.z, _MainColor.a);
+                half4 actualcolor = IF(isDMX() > 0, dmxcol *_MainColor * getEmissionColor(), _MainColor * getEmissionColor());
+                half4 color = lerp(half4(0,0,0,_MainColor.a), actualcolor, getGlobalIntensity());
+                // half3 newColor = RGB2HSV(color.rgb);
+                // newColor.y -= 0.1;
+                // color.rgb = hsb2rgb(newColor);
+
+                color = color * getFinalIntensity();
+                color = color * _UniversalIntensity;
+                color = color * i.rgbIntensity.w;
+                fixed4 col = half4(1,1,1,1);
+                fixed4 alphaMask = tex2D(_MainTex, i.uv2);
+                half2 laserUV = i.uv2;
+                col *= color;
+
+                //Draw Beams
+                half scroll = IF(isDMX() > 0, i.flatnessBeamCountSpinThickness.z, getScrollSpeed());
+                laserUV.x += _Time.y * scroll;
+                half beamcount = IF(isDMX() > 0, round(i.flatnessBeamCountSpinThickness.y), getLaserCount());
+                laserUV.x = frac(laserUV.x * beamcount);
+                laserUV.x = laserUV.x - 0.5;
+                half thiknes = IF(isDMX() > 0, i.flatnessBeamCountSpinThickness.w, getLaserThickness());
+
+                // Transparency (with gradation)
+                //half dist = normalize(distance(i.worldPos, half4(0,0,0,0)));
+                // fade = lerp(1,fade, pow(dist, _FadeAmt));
+
+                half beams = (beamcount * thiknes * 0.1) / abs(laserUV.x);
+                half transv = pow((-i.uv2.y + 1), _EndFade);
+                col = col * beams;
+
+                col += pow(-laserUV.y+1,_InternalShineLength*1.5) * _InternalShine * color;
+
+                // half beamGradCorrect = .2 / (1.-laserUV.y);
+                // col *= beamGradCorrect;
+                // Clamping here softens the depiction
+                col = clamp(0, _LaserSoftening, col);
+
+                // col = lerp(col, col*10, _ZConeFlatness/1.999);
+                // half edgeFadeL = distance(i.uv2.x, 0.75);
+                // half edgeFadeR = distance(i.uv2.x, 0.25);
+                // half4 edgee = lerp(half4(0,0,0,0), col, pow(edgeFadeR * edgeFadeL, _FadeStrength));
+                // col = lerp(col, edgee, _ZConeFlatness/1.999);
+
+                // col.xyz += rimlight.xyz;
+                // col *= fade;
+                col = lerp(half4(0,0,0,0), col, transv);
+                half pi = 3.14159;
+                half edgeMask = clamp((((sin((12.5 * i.uv2.x) + 4.75)) ))/pi * 6, 0,1);
+                edgeMask = 1 - edgeMask;
+                if(i.uv2.y > 0.99)
+                {
+                    discard;
+                    return half4(0,0,0,0);
+                }
+
+                // col = col * col *;
+                // half4 flatCol = col * flatEdgeMask.r;
+                half flatness = IF(isDMX() > 0, i.flatnessBeamCountSpinThickness.x, getConeFlatness());
+
+                half4 flatCol = col * edgeMask;
+                col = lerp(flatCol, col, pow(((flatness/2.0) - 1.0)*-1, 0.95));
+                col *= getFinalIntensity() * _UniversalIntensity * i.rgbIntensity.w;
+                return col;
+            }
+            ENDCG
+        }
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
+    SubShader
+    {
 		Tags { "RenderType"="Transparent" "Queue" = "Transparent+1" }
 		Cull Off
 		Blend One One

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-FixtureMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-FixtureMesh.shader
@@ -52,6 +52,251 @@
 		_DecorativeEmissiveMap("Decorative Emissive Map", 2D) = "black" {}
 		_DecorativeEmissiveMapStrength("Decorative Emissive Map Strength", Range(0,1)) = 0
 	}
+
+	// copied BIRP and updated for URP
+	// URP subshader must be first
+	SubShader
+	{
+		Tags { "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderingPipeline" = "UniversalPipeline" }
+
+		Pass
+	    {
+	        Name "UniversalForward"
+		    Tags { "LightMode" = "UniversalForward" }
+		    CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_fwdbase
+            #pragma multi_compile_instancing
+		    // #pragma multi_compile _ DOTS_INSTANCING_ON
+            #pragma shader_feature_local _LIGHTING_MODEL
+            //REMOVE THIS WHEN FINISHED DEBUGGING
+            //#pragma target 4.5
+
+            #define GEOMETRY
+
+            #ifndef UNITY_PASS_FORWARDBASE
+            #define UNITY_PASS_FORWARDBASE
+            #endif
+
+            #define FIXTURE_EMIT
+            #define VRSL_DMX
+            //DEBUGGING BUFFER
+
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "AutoLight.cginc"
+
+		    struct appdata
+	        {
+		        float4 vertex : POSITION;
+		        float2 uv : TEXCOORD0;
+		        float2 uv1 : TEXCOORD1;
+		        float2 uv2 : TEXCOORD2;
+		        float3 normal : NORMAL;
+		        float3 tangent : TANGENT;
+		        float4 color : COLOR;
+		        UNITY_VERTEX_INPUT_INSTANCE_ID
+	        };
+
+	        struct v2f
+	        {
+		        float4 pos : SV_POSITION;
+		        float2 uv : TEXCOORD0;
+		        float2 uv1 : TEXCOORD1;
+		        float2 uv2 : TEXCOORD2;
+		        float3 btn[3] : TEXCOORD3; //TEXCOORD2, TEXCOORD3 | bitangent, tangent, worldNormal
+		        float3 worldPos : TEXCOORD6;
+		        #ifdef _LIGHTING_MODEL
+			        UNITY_LIGHTING_COORDS(7,8)
+			        float4 eyeVec : TEXCOORD12;
+			        half4 ambientOrLightmapUV : TEXCOORD13;
+		        #else
+			        float3 objPos : TEXCOORD7;
+			        float3 objNormal : TEXCOORD8;
+	                float4 _ShadowCoord : TEXCOORD11;
+		        #endif
+		        float4 color : COLOR;
+		        float2 intensityStrobe : TEXCOORD9;
+		        float4 rgbColor : TEXCOORD10;
+		        UNITY_VERTEX_INPUT_INSTANCE_ID
+		        UNITY_VERTEX_OUTPUT_STEREO
+	        };
+
+	        #include "../Shared/VRSL-Defines.cginc"
+	        #include "../Shared/VRSL-DMXFunctions.cginc"
+	        #include "../Shared/VRSL-LightingFunctions.cginc"
+	        #include "../Shared/VRSL-StandardLighting.cginc"
+	        #include "VRSL-StandardMover-Vertex.cginc"
+	        ENDCG
+	    }
+
+		Pass
+	    {
+	        Name "ShadowCaster"
+		    Tags { "LightMode" = "ShadowCaster" }
+
+		    CGPROGRAM
+		    #define FIXTURE_SHADOWCAST
+		    #define VRSL_DMX
+		    #pragma vertex vert
+		    #pragma fragment frag
+		    #pragma multi_compile_shadowcaster
+		    #pragma multi_compile_instancing
+		    // #pragma multi_compile _ DOTS_INSTANCING_ON
+		    #include "UnityCG.cginc"
+
+		    struct appdata
+		    {
+			    float4 vertex : POSITION;
+			    float2 uv : TEXCOORD0;
+			    float2 uv1 : TEXCOORD1;
+			    float2 uv2 : TEXCOORD2;
+			    float3 normal : NORMAL;
+			    float3 tangent : TANGENT;
+			    float4 color : COLOR;
+			    UNITY_VERTEX_INPUT_INSTANCE_ID
+		    };
+
+		    struct v2f
+		    {
+			    float4 pos : SV_POSITION;
+			    float3 normal: TEXCOORD0;
+		        float4 color : COLOR; // generally unused here, but makes the compiler happy
+			    UNITY_VERTEX_INPUT_INSTANCE_ID
+			    UNITY_VERTEX_OUTPUT_STEREO
+		    };
+
+		    #include "../Shared/VRSL-Defines.cginc"
+		    #include "../Shared/VRSL-DMXFunctions.cginc"
+		    #include "VRSL-StandardMover-Vertex.cginc"
+	        ENDCG
+	    }
+
+        // DepthOnly and DepthNormals MUST utilize exact same rotations as the forward pass for vertex rotation to have rendering continuity
+
+		Pass
+	    {
+	        Name "DepthOnly"
+		    Tags { "LightMode" = "DepthOnly" }
+
+		    CGPROGRAM
+		    #define FIXTURE_EMIT
+		    #define VRSL_DMX
+		    #pragma vertex vert
+		    #pragma fragment frag
+		    #pragma multi_compile_instancing
+		    // #pragma multi_compile _ DOTS_INSTANCING_ON
+		    #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "AutoLight.cginc"
+
+		    struct appdata
+	        {
+		        float4 vertex : POSITION;
+		        float2 uv : TEXCOORD0;
+		        float2 uv1 : TEXCOORD1;
+		        float2 uv2 : TEXCOORD2;
+		        float3 normal : NORMAL;
+		        float3 tangent : TANGENT;
+		        float4 color : COLOR;
+		        UNITY_VERTEX_INPUT_INSTANCE_ID
+	        };
+
+	        struct v2f
+	        {
+		        float4 pos : SV_POSITION;
+		        float2 uv : TEXCOORD0;
+		        float2 uv1 : TEXCOORD1;
+		        float2 uv2 : TEXCOORD2;
+		        float3 btn[3] : TEXCOORD3; //TEXCOORD2, TEXCOORD3 | bitangent, tangent, worldNormal
+		        float3 worldPos : TEXCOORD6;
+		        #ifdef _LIGHTING_MODEL
+			        UNITY_LIGHTING_COORDS(7,8)
+			        float4 eyeVec : TEXCOORD12;
+			        half4 ambientOrLightmapUV : TEXCOORD13;
+		        #else
+			        float3 objPos : TEXCOORD7;
+			        float3 objNormal : TEXCOORD8;
+	                float4 _ShadowCoord : TEXCOORD11;
+		        #endif
+		        float4 color : COLOR;
+		        float2 intensityStrobe : TEXCOORD9;
+		        float4 rgbColor : TEXCOORD10;
+		        UNITY_VERTEX_INPUT_INSTANCE_ID
+		        UNITY_VERTEX_OUTPUT_STEREO
+	        };
+
+	        #include "../Shared/VRSL-Defines.cginc"
+	        #include "../Shared/VRSL-DMXFunctions.cginc"
+	        #include "../Shared/VRSL-LightingFunctions.cginc"
+	        #include "../Shared/VRSL-StandardLighting.cginc"
+	        #include "VRSL-StandardMover-Vertex.cginc"
+	        ENDCG
+	    }
+
+		Pass
+	    {
+	        Name "DepthNormals"
+		    Tags { "LightMode" = "DepthNormals" }
+
+		    CGPROGRAM
+		    #define FIXTURE_EMIT
+		    #define VRSL_DMX
+		    #pragma vertex vert
+		    #pragma fragment frag
+		    #pragma multi_compile_instancing
+		    // #pragma multi_compile _ DOTS_INSTANCING_ON
+		    #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "AutoLight.cginc"
+
+		    struct appdata
+	        {
+		        float4 vertex : POSITION;
+		        float2 uv : TEXCOORD0;
+		        float2 uv1 : TEXCOORD1;
+		        float2 uv2 : TEXCOORD2;
+		        float3 normal : NORMAL;
+		        float3 tangent : TANGENT;
+		        float4 color : COLOR;
+		        UNITY_VERTEX_INPUT_INSTANCE_ID
+	        };
+
+	        struct v2f
+	        {
+		        float4 pos : SV_POSITION;
+		        float2 uv : TEXCOORD0;
+		        float2 uv1 : TEXCOORD1;
+		        float2 uv2 : TEXCOORD2;
+		        float3 btn[3] : TEXCOORD3; //TEXCOORD2, TEXCOORD3 | bitangent, tangent, worldNormal
+		        float3 worldPos : TEXCOORD6;
+		        #ifdef _LIGHTING_MODEL
+			        UNITY_LIGHTING_COORDS(7,8)
+			        float4 eyeVec : TEXCOORD12;
+			        half4 ambientOrLightmapUV : TEXCOORD13;
+		        #else
+			        float3 objPos : TEXCOORD7;
+			        float3 objNormal : TEXCOORD8;
+	                float4 _ShadowCoord : TEXCOORD11;
+		        #endif
+		        float4 color : COLOR;
+		        float2 intensityStrobe : TEXCOORD9;
+		        float4 rgbColor : TEXCOORD10;
+		        UNITY_VERTEX_INPUT_INSTANCE_ID
+		        UNITY_VERTEX_OUTPUT_STEREO
+	        };
+
+	        #include "../Shared/VRSL-Defines.cginc"
+	        #include "../Shared/VRSL-DMXFunctions.cginc"
+	        #include "../Shared/VRSL-LightingFunctions.cginc"
+	        #include "../Shared/VRSL-StandardLighting.cginc"
+	        #include "VRSL-StandardMover-Vertex.cginc"
+	        ENDCG
+	    }
+	}
+
+// Original BIRP shader
 		SubShader
 	{
 		
@@ -159,9 +404,9 @@
 		{
 			float4 pos : SV_POSITION;
 			float3 normal: TEXCOORD0;
+            float4 color : COLOR;
 			UNITY_VERTEX_INPUT_INSTANCE_ID
 			UNITY_VERTEX_OUTPUT_STEREO
-			//SHADOW_COORDS(11)
 		};
 		#include "../Shared/VRSL-Defines.cginc"
 		#include "../Shared/VRSL-DMXFunctions.cginc"

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-ProjectionMesh.shader
@@ -147,6 +147,94 @@
 
 
 	}
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+        }
+
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Cull Front
+            Ztest GEqual
+            ZWrite Off
+            Blend DstColor [_BlendDst]
+            BlendOp Add
+            Offset -1, -1
+            Lighting Off
+
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma shader_feature_local _MULTISAMPLEDEPTH
+            //#pragma multi_compile_fog
+            #pragma multi_compile_instancing
+            #pragma instancing_options assumeuniformscaling
+            //#pragma multi_compile _DNENABLER_NONE _DNENABLER_USEDNTEXTURE
+            #define PROJECTION_YES //To identify the pass in the vert/frag shaders
+            #define PROJECTION_MOVER
+            #define VRSL_DMX
+
+            #include "UnityCG.cginc"
+            #include "../Shared/VRSL-Defines.cginc" //Property Defines are here
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float3 texcoord : TEXCOORD1;
+                float4 color : COLOR;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float4 projectionorigin : TEXCOORD2;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 ray : TEXCOORD2;
+                float4 screenPos : TEXCOORD4;
+                float4 color : COLOR;
+                float3 normal : TEXCOORD3;
+                float2 dmx: TEXCOORD10;
+                float4 projectionorigin : TEXCOORD5;
+                float4 worldDirection : TEXCOORD6;
+                float4 worldPos : TEXCOORD7;
+                float3 viewDir : TEXCOORD8;
+                float3 intensityStrobeWidth : TEXCOORD9;
+                float4 goboPlusSpinPanTilt : TEXCOORD11;
+                float4 rgbColor : TEXCOORD12;
+                float4 emissionColor : TEXCOORD13;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "../Shared/VRSL-DMXFunctions.cginc" //Custom Functions
+            #include "VRSL-StandardMover-ProjectionFrag.cginc" //Fragment Shader is here
+            #include "VRSL-StandardMover-Vertex.cginc" //Vertex Shader is here
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
 		SubShader
 	{
 		

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-Vertex-URP.cginc
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-Vertex-URP.cginc
@@ -1,0 +1,962 @@
+﻿//This file contains the vertex and fragment functions for both the ForwardBase and Forward Add pass.
+//FOR MOVER LIGHT SHADER
+#define IF(a, b, c) lerp(b, c, step((fixed) (a), 0));
+
+#ifdef VRSL_DMX
+half4 calculateRotations(appdata v, half4 input, int normalsCheck, half pan, half tilt)
+{
+    //	input = IF(worldspacecheck == 1, half4(UnityObjectToWorldNormal(v.normal).x * -1.0, UnityObjectToWorldNormal(v.normal).y * -1.0, UnityObjectToWorldNormal(v.normal).z * -1.0, 1), input)
+    //CALCULATE BASE ROTATION. MORE FUN MATH. THIS IS FOR PAN.
+    half angleY = radians(getOffsetY() + pan);
+    half c, s;
+    sincos(angleY, s, c);
+
+    half3x3 rotateYMatrix = half3x3(c, -s, 0,
+                                    s, c, 0,
+                                    0, 0, 1);
+    half3 BaseAndFixturePos = input.xyz;
+
+    //INVERSION CHECK
+    rotateYMatrix = checkPanInvertY() == 1 ? transpose(rotateYMatrix) : rotateYMatrix;
+
+    half3 localRotY = mul(rotateYMatrix, BaseAndFixturePos);
+    //LOCALROTY IS NEW ROTATION
+
+
+    //CALCULATE FIXTURE ROTATION. WOO FUN MATH. THIS IS FOR TILT.
+
+    //set new origin to do transform
+    half3 newOrigin = input.w * _FixtureRotationOrigin.xyz;
+    //if input.w is 1 (vertex), origin changes
+    //if input.w is 0 (normal/tangent), origin doesn't change
+
+    //subtract new origin from original origin for blue vertexes
+    input.xyz = v.color.b == 1.0 ? input.xyz - newOrigin : input.xyz;
+
+
+    //DO ROTATION
+
+
+    //#if defined(PROJECTION_YES)
+    //buffer[3] = GetTiltValue(sector);
+    //#endif
+    half angleX = radians(getOffsetX() + tilt);
+    sincos(angleX, s, c);
+    half3x3 rotateXMatrix = half3x3(1, 0, 0,
+                                    0, c, -s,
+                                    0, s, c);
+
+    //half4 fixtureVertexPos = input;
+
+    //INVERSION CHECK
+    rotateXMatrix = checkTiltInvertZ() == 1 ? transpose(rotateXMatrix) : rotateXMatrix;
+
+    //half4 localRotX = mul(rotateXMatrix, fixtureVertexPos);
+    //LOCALROTX IS NEW ROTATION
+
+
+    //COMBINED ROTATION FOR FIXTURE
+
+    half3x3 rotateXYMatrix = mul(rotateYMatrix, rotateXMatrix);
+    half3 localRotXY = mul(rotateXYMatrix, input.xyz);
+    //LOCALROTXY IS COMBINED ROTATION
+
+    //Apply fixture rotation ONLY to those with blue vertex colors
+
+    //apply LocalRotXY rotation then add back old origin
+    input.xyz = v.color.b == 1.0 ? localRotXY + newOrigin : input.xyz;
+    //input.xyz = v.color.b == 1.0 ? input.xyz + newOrigin : input.xyz;
+
+    //appy LocalRotY rotation to lightfixture base;
+    input.xyz = v.color.g == 1.0 ? localRotY : input.xyz;
+
+    return input;
+}
+
+half4 InvertVolumetricRotations(half4 input, half pan, half tilt)
+{
+    half sX, cX, sY, cY;
+    half angleY = radians(getOffsetY() + pan);
+    sincos(angleY, sY, cY);
+    half3x3 rotateYMatrix = half3x3(cY, sY, 0,
+                                    -sY, cY, 0,
+                                    0, 0, 1);
+    half3 BaseAndFixturePos = input.xyz;
+
+    //INVERSION CHECK
+    rotateYMatrix = checkPanInvertY() == 1 ? transpose(rotateYMatrix) : rotateYMatrix;
+
+    //half4 localRotY = mul(rotateYMatrix, BaseAndFixturePos);
+    //LOCALROTY IS NEW ROTATION
+
+
+    half tiltOffset = 90.0;
+    tiltOffset = checkTiltInvertZ() == 1 ? -tiltOffset : tiltOffset;
+    //set new origin to do transform
+    half4 newOrigin = input.w * _FixtureRotationOrigin;
+    input.xyz -= newOrigin;
+
+
+    half angleX = radians(getOffsetX() + (tiltOffset) + tilt);
+    sincos(angleX, sX, cX);
+    half3x3 rotateXMatrix = half3x3(1, 0, 0,
+                                    0, cX, sX,
+                                    0, -sX, cX);
+
+    //half4 fixtureVertexPos = input;
+
+    //INVERSION CHECK
+    rotateXMatrix = checkTiltInvertZ() == 1 ? transpose(rotateXMatrix) : rotateXMatrix;
+    //half4 localRotX = mul(rotateXMatrix, fixtureVertexPos);
+
+    half3x3 rotateXYMatrix = mul(rotateXMatrix, rotateYMatrix);
+    half3 localRotXY = mul(rotateXYMatrix, input);
+
+    input.xyz = localRotXY;
+    input.xyz += newOrigin;
+    return input;
+}
+#endif
+
+
+half4 CalculateProjectionScaleRange(appdata v, half4 input, half scalar)
+{
+    half4 oldinput = input;
+    half4 newOrigin = input.w * _ProjectionRangeOrigin;
+    input.xyz = input.xyz - newOrigin;
+    //Do stretch
+    input.xyz = input.xyz * scalar;
+    input.xyz = input.xyz + newOrigin;
+    input.xyz = (v.color.r == 1.0 && ceil(v.color.g) == 1) ? input.xyz : oldinput;
+    return input;
+}
+
+half4 ConeScale(appdata v, half4 input, half scalar)
+{
+    //Set New Origin
+    #ifdef VRSL_DMX
+    half4 newOrigin = input.w * _FixtureRotationOrigin;
+    input.xyz = input.xyz - newOrigin;
+    //scalar = -scalar;
+
+    half4x4 scaleMatrix = half4x4(scalar, 0, 0, 0,
+                                  0, 1, 0, 0,
+                                  0, 0, scalar, 0,
+                                  0, 0, 0, 1);
+
+    input = mul(input, scaleMatrix);
+    input.xyz = input.xyz + newOrigin;
+    return input;
+    #endif
+    #ifdef VRSL_AUDIOLINK
+		half4 newOrigin = input.w * _FixtureRotationOrigin; 
+		input.xyz = input.xyz - newOrigin;
+		//scalar = -scalar;
+
+		half4x4 scaleMatrix 	= half4x4(scalar,	0,	0,	0,
+												0,	scalar,  0,	0,
+												0,	0,	1,0,
+												0,	0,	0,	1);
+
+		input = mul(input,scaleMatrix);
+		input.xyz = input.xyz + newOrigin;
+		return input;
+    #endif
+}
+#ifdef VRSL_DMX
+half4 CalculateConeWidth(appdata v, half4 input, half scalar, uint dmx)
+{
+    #if defined(VOLUMETRIC_YES)
+
+			// if((ceil(v.color.r) > 0 && ceil(v.color.g) < 1 && ceil(v.color.b) > 0 ))
+			// {
+
+				//Set New Origin
+				half4 newOrigin = input.w * _FixtureRotationOrigin; 
+				input.xyz = input.xyz - newOrigin;
+				scalar = -scalar;
+
+				// Do Transformation
+
+				//input.xy = input.xy + v.normal.xy * distanceFromFixture;
+			//	v.tangent.y *= 0.1235;
+    #ifdef WASH
+					scalar *= 2.0;
+					scalar -= 2.50;
+					//scalar = clamp(scalar, 0.0, 50.0);
+    #endif
+				// if(v.color.r < 0.9)
+				// {
+					half distanceFromFixture = (v.uv.x) * (scalar);
+					distanceFromFixture = lerp(0, distanceFromFixture, pow(v.uv.x, _ConeSync));
+
+					input.z = (input.z) + (-v.normal.z) * (distanceFromFixture);
+					input.x = (input.x) + (-v.normal.x) * (distanceFromFixture);
+					half3 originStretch = input.xyz;
+					half3 stretchedcoords = ((-v.tangent.y)*getMaxConeLength(dmx));
+					input.xyz = lerp(originStretch, (originStretch * stretchedcoords), pow(v.uv.x,lerp(1, 0.1, v.uv.x)-0.5));
+					input.xyz = IF(v.uv.x < 0.001, originStretch, input.xyz);
+
+				input.xyz = input.xyz + newOrigin;
+
+				return input;
+			// }
+			// else
+			// {
+			// 	return input;
+			// }
+    #endif
+
+    #if defined(PROJECTION_YES)
+			if(ceil(v.color.g) >= 0.9 && ceil(v.color.r) >= 0.5)
+			{
+				half4 newOrigin = input.w * _ProjectionRangeOrigin; 
+				input.xyz = input.xyz - newOrigin;
+
+				// Do Transformation
+				half distanceFromFixture = (v.texcoord.x) * scalar;
+				//input.xy = input.xy + v.normal.xy * distanceFromFixture;
+				input.x = (input.x) + (v.normal.x) * distanceFromFixture;
+				input.z = (input.z) + (v.normal.z) * distanceFromFixture;
+
+				//Rest Origin
+				input.xyz = input.xyz + newOrigin;
+
+				return input;
+
+			}
+			else
+			{
+				return input;
+			}
+    #endif
+    return input;
+}
+#endif
+#ifdef VRSL_AUDIOLINK
+	half4 CalculateConeWidth(appdata v, half4 input, half scalar)
+	{
+#if defined(VOLUMETRIC_YES)
+#ifdef WASH
+					scalar *= 2.5;
+					scalar += 2.50;
+					//scalar = clamp(scalar, 0.0, 50.0);
+#endif
+
+				//Set New Origin
+				half4 newOrigin = input.w * _FixtureRotationOrigin; 
+				input.xyz = input.xyz - newOrigin;
+				scalar = -scalar;
+				// Do Transformation
+				half distanceFromFixture = (v.uv.x) * (scalar);
+				distanceFromFixture = lerp(0, distanceFromFixture, pow(v.uv.x, 0.05));
+				input.y = (input.y) + (-v.normal.y) * (distanceFromFixture);
+				input.x = (input.x) + (-v.normal.x) * (distanceFromFixture);
+				half3 originStretch = input.xyz;
+				half3 stretchedcoords = (v.tangent.z*getMaxConeLength());
+				input.xyz = lerp(originStretch, (input.xyz * stretchedcoords), pow(v.uv.x,lerp(1, 0.1, v.uv.x)-0.5));
+				input.xyz = IF(v.uv.x < 0.001, originStretch, input.xyz);
+				
+				input.xyz = input.xyz + newOrigin;
+
+				return input;
+#endif
+
+#if defined(PROJECTION_YES)
+			if(ceil(v.color.g) >= 0.9 && ceil(v.color.r) >= 0.5)
+			{
+				half4 newOrigin = input.w * _ProjectionRangeOrigin; 
+				input.xyz = input.xyz - newOrigin;
+
+				// Do Transformation
+				half distanceFromFixture = (v.texcoord.x) * scalar;
+				//input.xy = input.xy + v.normal.xy * distanceFromFixture;
+				input.x = (input.x) + (v.normal.x) * distanceFromFixture;
+				input.z = (input.z) + (v.normal.z) * distanceFromFixture;
+
+				//Rest Origin
+				input.xyz = input.xyz + newOrigin;
+				return input;
+			}
+			else
+			{
+				return input;
+			}
+#endif
+		return input;
+
+	}
+#endif
+
+
+inline float4 CalculateFrustumCorrection()
+{
+    float x1 = -UNITY_MATRIX_P._31 / (UNITY_MATRIX_P._11 * UNITY_MATRIX_P._34);
+    float x2 = -UNITY_MATRIX_P._32 / (UNITY_MATRIX_P._22 * UNITY_MATRIX_P._34);
+    return float4(
+        x1, x2, 0, UNITY_MATRIX_P._33 / UNITY_MATRIX_P._34 + x1 * UNITY_MATRIX_P._13 + x2 * UNITY_MATRIX_P._23);
+}
+
+half2 GetStripeInfo(uint goboSelection)
+{
+    switch (goboSelection)
+    {
+    case 2:
+        return half2(_StripeSplit, _StripeSplitStrength);
+    case 3:
+        return half2(_StripeSplit2, _StripeSplitStrength2);
+    case 4:
+        return half2(_StripeSplit3, _StripeSplitStrength3);
+    case 5:
+        return half2(_StripeSplit4, _StripeSplitStrength4);
+    case 6:
+        return half2(_StripeSplit5, _StripeSplitStrength5);
+    case 7:
+        return half2(_StripeSplit6, _StripeSplitStrength6);
+    case 8:
+        return half2(_StripeSplit7, _StripeSplitStrength7);
+    default:
+        return half2(0.0f, 0.0f);
+    }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////START VERTEX SHADERS///////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+//VERTEX SHADER
+v2f vert(appdata v)
+{
+    v2f o;
+    UNITY_SETUP_INSTANCE_ID(v);
+    UNITY_INITIALIZE_OUTPUT(v2f, o); //DON'T INITIALIZE OR IT WILL BREAK PROJECTION
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+    UNITY_TRANSFER_INSTANCE_ID(v, o);
+
+    ////////////////////////////////////////START DMX VERTEX//////////////////////////////////////////////////////////////////////
+    #ifdef VRSL_DMX
+    uint dmx = getDMXChannel();
+    half oscConeWidth = getDMXConeWidth(dmx);
+    half oscPanValue = GetPanValue(dmx);
+    half oscTiltValue = GetTiltValue(dmx);
+
+
+    v.vertex = CalculateConeWidth(v, v.vertex, oscConeWidth, dmx);
+    v.vertex = CalculateProjectionScaleRange(v, v.vertex, _ProjectionRange);
+
+    #if defined(VOLUMETRIC_YES)
+    #ifdef _ALPHATEST_ON
+				v.vertex = ConeScale(v, v.vertex, _MinimumBeamRadius-0.25);
+    #else
+				v.vertex = ConeScale(v, v.vertex, _MinimumBeamRadius);
+    #endif
+    #endif
+    //calculate rotations for verts
+    v.vertex = calculateRotations(v, v.vertex, 0, oscPanValue, oscTiltValue);
+    #if defined(PROJECTION_YES)
+			o.projectionorigin = calculateRotations(v, _ProjectionRangeOrigin, 0, oscPanValue, oscTiltValue);
+    #endif
+    #if defined(VOLUMETRIC_YES)
+			o.coneWidth = oscConeWidth + 1.5;
+			float3 worldCam;
+			worldCam.x = unity_CameraToWorld[0][3];
+			worldCam.y = unity_CameraToWorld[1][3];
+			worldCam.z = unity_CameraToWorld[2][3];
+			float3 objCamPos = mul(unity_WorldToObject, float4(worldCam, 1)).xyz;
+			objCamPos = InvertVolumetricRotations(float4(objCamPos,1), oscPanValue, oscTiltValue).xyz;
+			
+    #ifdef _ALPHATEST_ON
+				half len = length(objCamPos.xy);
+				len *= (_BlindingAngleMod);
+    #else
+				half len = length(objCamPos.xy);
+				len *= (len * _BlindingAngleMod);
+    #endif
+			float4 originScreenPos = ComputeScreenPos(UnityObjectToClipPos(_FixtureRotationOrigin));
+			float2 originScreenUV = originScreenPos.xy / originScreenPos.w;
+			o.camAngleCamfade.x = saturate((1-distance(half2(0.5, 0.5), originScreenUV))-0.5);
+			
+			//camAngle = lerp(1, camAngle, len);
+			//o.blindingEffect = lerp(1, o.blindingEffect * 2.5, o.camAngleCamfade.x);
+		//	 #ifndef WASH
+
+    #ifdef _ALPHATEST_ON
+					o.blindingEffect = clamp(0.6/len,1.0,20.0);
+					half endBlind = 1.0;
+					o.blindingEffect = lerp(endBlind, o.blindingEffect, o.camAngleCamfade.x);
+    #else
+					o.blindingEffect = clamp(0.6/len,1.0,20.0);
+					half endBlind = lerp(1.0, o.blindingEffect, 0.15);
+					o.blindingEffect = lerp(endBlind, o.blindingEffect * 2.2, o.camAngleCamfade.x);	
+    #endif
+    // #else
+    // 	o.blindingEffect = lerp(1, o.blindingEffect * 2.0, o.camAngleCamfade.x);
+    //#endif
+    //o.camAngle = camAngle;
+    //o.viewDir.yzw = objCamPos.xyz;
+    #endif
+
+    //calculate rotations for normals, cast to half4 first with 0 as w
+    half4 newNormals = half4(v.normal.x, v.normal.y, v.normal.z, 0);
+    newNormals = calculateRotations(v, newNormals, 1, oscPanValue, oscTiltValue);
+    v.normal = newNormals.xyz;
+
+    //calculate rotations for tangents, cast to half4 first with 0 as w
+    // half4 newTangent = half4(v.tangent.x, v.tangent.y, v.tangent.z, 0);
+    // newTangent = calculateRotations(v, newTangent, 1, oscPanValue, oscTiltValue);
+    // v.tangent = newTangent.xyz;
+
+    #if defined(FIXTURE_SHADOWCAST)
+			//o.pos = UnityObjectToClipPos(v.vertex);
+			o.pos = UnityClipSpaceShadowCasterPos(v.vertex, v.normal);
+			o.pos = UnityApplyLinearShadowBias(o.pos);
+			//o.normal = v.normal;
+			//TRANSFER_SHADOW_CASTER_NORMALOFFSET(o);
+			return o;
+    #endif
+
+    //original surface shader related code
+    #if !defined(VOLUMETRIC_YES) && !defined(FIXTURE_SHADOWCAST)
+    half3 worldNormal = UnityObjectToWorldNormal(v.normal);
+    half3 tangent = UnityObjectToWorldDir(v.tangent);
+    half3 bitangent = cross(tangent, worldNormal);
+    #endif
+
+
+    #if !defined(PROJECTION_YES) && !defined(VOLUMETRIC_YES) && !defined(FIXTURE_SHADOWCAST)
+    o.pos = UnityObjectToClipPos(v.vertex);
+    o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+    #endif
+
+    #if defined(PROJECTION_YES)
+
+			//UNITY_SETUP_INSTANCE_ID(v);
+			UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+			//move verts to clip space
+			o.pos = UnityObjectToClipPos(v.vertex);
+			o.emissionColor = getEmissionColor();
+			//o.uv = TRANSFORM_TEX(v.uv, _ProjectionMainTex);
+			//get screen space position of verts
+			o.screenPos = ComputeScreenPos(o.pos);
+			//Putting in the vertex position before the transformation seems to somewhat move the projection correctly, but is still incorrect...?
+			o.ray = UnityObjectToViewPos(v.vertex).xyz;
+			//invert z axis so that it projects from camera properly
+			o.ray *= half3(1,1,-1);
+			//saving vertex color incase needing to perform rotation calculation in fragment shader
+			o.color = v.color;
+			o.dmx.x = (half)dmx;
+
+			o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+
+			//For Mirror Depth Correction
+			o.worldDirection.xyz = o.worldPos.xyz - _WorldSpaceCameraPos;
+			// pack correction factor into direction w component to save space
+			o.worldDirection.w = dot(o.pos, CalculateFrustumCorrection());
+			//o.viewDir = normalize(mul(UNITY_MATRIX_MV, v.vertex).xyz); // get normalized view dir
+			o.viewDir = normalize(UnityObjectToViewPos(v.vertex.xyz));
+			o.viewDir /= o.viewDir.z; // rescale vector so z is 1.0
+			//GET DMX/DMX VALUES
+			o.intensityStrobeWidth = half3(GetDMXIntensity(dmx, 1.0), GetStrobeOutput(dmx), oscConeWidth);
+    #ifdef WASH
+				half spinSpeed = 0.0;
+    #else
+				half spinSpeed = getGoboSpinSpeed(dmx);
+    #endif
+			o.goboPlusSpinPanTilt = half4(getDMXGoboSelection(dmx), spinSpeed, oscPanValue, oscTiltValue);
+			o.rgbColor = GetDMXColor(dmx);
+			if(((all(o.rgbColor <= half4(0.01,0.01,0.01,1)) || o.intensityStrobeWidth.x <= 0.01) && isDMX() == 1) || getGlobalIntensity() <= 0.005 || getFinalIntensity() <= 0.005 || all(o.emissionColor <= half4(0.005, 0.005, 0.005, 1.0)))
+			{
+				v.vertex = half4(0,0,0,0);
+				o.pos = UnityObjectToClipPos(v.vertex);
+			} 
+
+			//o.normal = v.normal;
+    #endif
+
+
+    #if defined(UNITY_PASS_FORWARDBASE)
+    o.uv1 = v.uv1;
+    o.uv2 = v.uv2;
+    #endif
+
+
+    //Volumetric Part - Vertex Shader
+    #if defined(VOLUMETRIC_YES)
+			o.pos = UnityObjectToClipPos(v.vertex);
+			//UNITY_INITIALIZE_OUTPUT(v2f, o);
+			//UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+		//	o.viewDir = ObjSpaceViewDir(v.vertex);
+			o.screenPos = ComputeScreenPos (o.pos);
+			//o.uvClone = v.uv2;
+    #ifdef _HQ_MODE
+				o.uv2 = TRANSFORM_TEX(v.uv2, _NoiseTexHigh);
+    #else
+				o.uv2 = TRANSFORM_TEX(v.uv2, _NoiseTex);
+    #endif
+			o.uv = TRANSFORM_TEX(v.uv, _LightMainTex);
+			//o.uv = UnityStereoScreenSpaceUVAdjust(uv, sb)
+			COMPUTE_EYEDEPTH(o.screenPos.z);
+			UNITY_TRANSFER_FOG(o,o.vertex);
+			o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+			o.camAngleCamfade.y = saturate(distance(worldCam, o.worldPos) - 0.5);
+			//For Mirror Depth Correction
+			o.worldDirection.xyz = o.worldPos.xyz - _WorldSpaceCameraPos;
+			// pack correction factor into direction w component to save space
+			o.worldDirection.w = dot(o.pos, CalculateFrustumCorrection());
+			//o.color = v.color;
+			//o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+			//o.objPos = v.vertex;
+			o.objNormal = normalize(v.normal);
+			//o.bitan = bitangent;
+
+			//o.tan = tangent;
+			//o.norm = worldNormal;
+			//GETTING DATA FROM DMX TEXTURE
+			o.intensityStrobeGOBOSpinSpeed = half4(GetDMXIntensity(dmx, 1.0),GetStrobeOutput(dmx), getGoboSpinSpeed(dmx), getDMXGoboSelection(dmx));
+			o.intensityStrobeGOBOSpinSpeed.x = isDMX() == 1 ? o.intensityStrobeGOBOSpinSpeed.x : 1.0;
+    #if !defined(WASH)
+			uint gobo = isDMX() > 0 ? ceil(o.intensityStrobeGOBOSpinSpeed.w) : instancedGOBOSelection();
+			o.stripeInfo = GetStripeInfo(gobo);
+    #endif
+			o.rgbColor = GetDMXColor(dmx);
+			if(((all(o.rgbColor <= half4(0.005,0.005,0.005,1)) || o.intensityStrobeGOBOSpinSpeed.x <= 0.01) && isDMX() == 1) || getGlobalIntensity() <= 0.005 || getFinalIntensity() <= 0.005)
+			{
+				v.vertex = half4(0,0,0,0);
+				o.pos = UnityObjectToClipPos(v.vertex);
+			} 
+    #endif
+
+    //Projection Part - Vertex Shader
+    // #if defined(PROJECTION_YES)
+
+
+    // #endif
+
+    #if !defined(UNITY_PASS_SHADOWCASTER) && !defined(PROJECTION_YES) && !defined(VOLUMETRIC_YES)
+
+    o.color = v.color;
+    o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+
+
+    o.intensityStrobe = half2(GetDMXIntensity(dmx, 1.0), GetStrobeOutput(dmx));
+    o.rgbColor = GetDMXColor(dmx);
+    o.btn[0] = bitangent;
+    o.btn[1] = tangent;
+    o.btn[2] = worldNormal;
+    #ifdef _LIGHTING_MODEL
+			o.eyeVec.xyz = NormalizePerVertexNormal(o.worldPos.xyz - _WorldSpaceCameraPos);
+			o.ambientOrLightmapUV = VertexGIForward(v, o.worldPos, o.btn[2]);
+    #else
+    o.objPos = v.vertex;
+    o.objNormal = v.normal;
+    #endif
+    #if !defined(VOLUMETRIC_YES) && !defined (PROJECTION_YES)
+    UNITY_TRANSFER_SHADOW(o, o.uv);
+
+    #endif
+    #else
+    #if !defined(VOLUMETRIC_YES) && !defined(FIXTURE_SHADOWCAST)
+				o.color = v.color;
+    #endif
+    #endif
+    #endif
+    ////////////////////////////////////////END DMX VERTEX//////////////////////////////////////////////////////////////////////
+
+
+    ////////////////////////////////////////START AUDIOLINK VERTEX//////////////////////////////////////////////////////////////////////
+
+    #ifdef VRSL_AUDIOLINK
+		v.vertex = CalculateConeWidth(v, v.vertex, getConeWidth());
+		v.vertex = CalculateProjectionScaleRange(v, v.vertex, _ProjectionRange);
+
+    #if defined(VOLUMETRIC_YES)
+    #ifdef _ALPHATEST_ON
+				v.vertex = ConeScale(v, v.vertex, _MinimumBeamRadius-0.25);
+    #else
+				v.vertex = ConeScale(v, v.vertex, _MinimumBeamRadius);
+    #endif
+    #endif
+    //calculate rotations for verts
+    //v.vertex = calculateRotations(v, v.vertex, 0);
+    #if defined(PROJECTION_YES)
+    #ifdef RAW
+				o.globalFinalIntensity.x = getGlobalIntensity();
+				o.globalFinalIntensity.y = getFinalIntensity();
+    #else
+				o.audioGlobalFinalConeIntensity.x = GetAudioReactAmplitude();
+				o.audioGlobalFinalConeIntensity.y = getGlobalIntensity();
+				o.audioGlobalFinalConeIntensity.z = getFinalIntensity();
+				o.audioGlobalFinalConeIntensity.w = getConeWidth();
+    #endif
+
+			o.emissionColor = getEmissionColor();
+    #endif
+    #if defined(VOLUMETRIC_YES)
+    #ifdef RAW
+				o.globalFinalIntensity.x = getGlobalIntensity();
+				o.globalFinalIntensity.y = getFinalIntensity();
+    #else
+				o.audioGlobalFinalIntensity.x = GetAudioReactAmplitude();
+				o.audioGlobalFinalIntensity.y = getGlobalIntensity();
+				o.audioGlobalFinalIntensity.z = getFinalIntensity();
+    #endif
+			o.emissionColor = getEmissionColor();
+			float3 worldCam;
+			o.coneWidth = getConeWidth() + 1.25;
+			worldCam.x = unity_CameraToWorld[0][3];
+			worldCam.y = unity_CameraToWorld[1][3];
+			worldCam.z = unity_CameraToWorld[2][3];
+			half3 objCamPos = mul(unity_WorldToObject, float4(worldCam, 1)).xyz;
+			//objCamPos = InvertVolumetricRotations(float4(objCamPos,1)).xyz;
+			half len = length(objCamPos.xy);
+			len *= len;
+			o.camAngleLen.y = len;
+			float4 originScreenPos = ComputeScreenPos(UnityObjectToClipPos(half4(0,0,0,0)));
+			float2 originScreenUV = originScreenPos.xy / originScreenPos.w;
+			o.camAngleLen.x = saturate((1-distance(half2(0.5, 0.5), originScreenUV))-0.5);
+			o.camAngleLen.x = pow(o.camAngleLen.x, 0.5);
+			o.blindingEffect = clamp(0.6/len,1.0,8.0);
+			//camAngle = lerp(1, camAngle, len);
+
+
+    #ifndef WASH
+				half endBlind = lerp(1.0, o.blindingEffect, 0.35);
+				o.blindingEffect = lerp(endBlind, o.blindingEffect * 2.2, o.camAngleLen.x);
+    #else
+				o.blindingEffect = lerp(1, o.blindingEffect * 2.0, o.camAngleLen.x);
+    #endif
+    //o.camAngle = camAngle;
+    //o.viewDir.yzw = objCamPos.xyz;
+    #endif
+
+		//calculate rotations for normals, cast to half4 first with 0 as w
+		half4 newNormals = half4(v.normal.x, v.normal.y, v.normal.z, 0);
+		//newNormals = calculateRotations(v, newNormals, 1);
+		v.normal = newNormals.xyz;
+
+		//calculate rotations for tangents, cast to half4 first with 0 as w
+		half4 newTangent = half4(v.tangent.x, v.tangent.y, v.tangent.z, 0);
+		//newTangent = calculateRotations(v, newTangent, 1);
+		v.tangent = newTangent.xyz;
+
+		//original surface shader related code
+		half3 worldNormal = UnityObjectToWorldNormal(v.normal);
+		half3 tangent = UnityObjectToWorldDir(v.tangent);
+		half3 bitangent = cross(tangent, worldNormal);
+
+
+    #if !defined(PROJECTION_YES) && !defined(VOLUMETRIC_YES)
+			o.pos = UnityObjectToClipPos(v.vertex);
+			o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+    #endif
+
+    #if defined(PROJECTION_YES)
+
+			//UNITY_SETUP_INSTANCE_ID(v);
+			UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+			//move verts to clip space
+			o.pos = UnityObjectToClipPos(v.vertex);
+			//get screen space position of verts
+			o.screenPos = ComputeScreenPos(o.pos);
+			//Putting in the vertex position before the transformation seems to somewhat move the projection correctly, but is still incorrect...?
+			o.ray = UnityObjectToViewPos(v.vertex).xyz;
+			//invert z axis so that it projects from camera properly
+			o.ray *= half3(1,1,-1);
+			//saving vertex color incase needing to perform rotation calculation in fragment shader
+			o.color = v.color;
+			//o.sector.x = (half)sector;
+
+			o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+
+			//For Mirror Depth Correction
+			o.worldDirection.xyz = o.worldPos.xyz - _WorldSpaceCameraPos;
+			// pack correction factor into direction w component to save space
+			o.worldDirection.w = dot(o.pos, CalculateFrustumCorrection());
+			//o.viewDir = normalize(mul(UNITY_MATRIX_MV, v.vertex).xyz);
+			o.viewDir = normalize(UnityObjectToViewPos(v.vertex.xyz)); // get normalized view dir
+			o.viewDir /= o.viewDir.z; // rescale vector so z is 1.0
+    #ifdef RAW
+				if(o.globalFinalIntensity.x <= 0.005 || o.globalFinalIntensity.y <= 0.005 || all(o.emissionColor.xyz <= half4(0.005, 0.005, 0.005, 1.0)))
+				{
+					v.vertex = half4(0,0,0,0);
+					o.pos = UnityObjectToClipPos(v.vertex);
+				}
+    #else
+				if(o.audioGlobalFinalConeIntensity.x <= 0.005 || o.audioGlobalFinalConeIntensity.y <= 0.005 || o.audioGlobalFinalConeIntensity.z <= 0.005 || all(o.emissionColor.xyz <= half4(0.005, 0.005, 0.005, 1.0)))
+				{
+					v.vertex = half4(0,0,0,0);
+					o.pos = UnityObjectToClipPos(v.vertex);
+				}
+    #endif
+
+    //o.normal = v.normal;
+    #endif
+
+
+    #if defined(UNITY_PASS_FORWARDBASE)
+		o.uv1 = v.uv1;
+		o.uv2 = v.uv2;
+    #endif
+
+
+    //Volumetric Part - Vertex Shader
+    #if defined(VOLUMETRIC_YES)
+			o.pos = UnityObjectToClipPos(v.vertex);
+    #if _USE_DEPTH_LIGHT
+				o.screenPos = ComputeScreenPos (o.pos);
+    #else
+				o.screenPos = half4(0,0,0,0);
+    #endif
+			o.uvClone = v.uv2;
+    #ifdef _HQ_MODE
+				o.uv2 = TRANSFORM_TEX(v.uv2, _NoiseTexHigh);
+    #else
+				o.uv2 = TRANSFORM_TEX(v.uv2, _NoiseTex);
+    #endif
+			o.uv = TRANSFORM_TEX(v.uv, _LightMainTex);
+			//o.uv = UnityStereoScreenSpaceUVAdjust(uv, sb)
+    #if _USE_DEPTH_LIGHT
+				COMPUTE_EYEDEPTH(o.screenPos.z);
+    #endif
+			UNITY_TRANSFER_FOG(o,o.vertex);
+			o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+
+			//For Mirror Depth Correction
+    #if _USE_DEPTH_LIGHT
+				o.worldDirection.xyz = o.worldPos.xyz - _WorldSpaceCameraPos;
+				// pack correction factor into direction w component to save space
+				o.worldDirection.w = dot(o.pos, CalculateFrustumCorrection());
+    #else
+				o.worldDirection = half4(0,0,0,0);
+    #endif
+			o.color = v.color;
+			//o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+			o.objPos = v.vertex;
+			o.objNormal = v.normal;
+			o.stripeInfo = GetStripeInfo(instancedGOBOSelection());
+			o.norm = worldNormal;
+    #ifdef RAW
+				if(o.globalFinalIntensity.x <= 0.005 || o.globalFinalIntensity.y <= 0.005 || all(o.emissionColor.xyz <= half4(0.005, 0.005, 0.005, 1.0)))
+				{
+					v.vertex = half4(0,0,0,0);
+					o.pos = UnityObjectToClipPos(v.vertex);
+				}
+    #else
+				if(o.audioGlobalFinalIntensity.x <= 0.005 || o.audioGlobalFinalIntensity.y <= 0.005 || o.audioGlobalFinalIntensity.z <= 0.005 || all(o.emissionColor.xyz <= half4(0.005, 0.005, 0.005, 1.0)))
+				{
+					v.vertex = half4(0,0,0,0);
+					o.pos = UnityObjectToClipPos(v.vertex);
+				}
+    #endif
+    #endif
+
+    #if !defined(UNITY_PASS_SHADOWCASTER) && !defined(PROJECTION_YES) && !defined(VOLUMETRIC_YES)
+		
+		o.color = v.color;
+		o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+		o.btn[0] = bitangent;
+		o.btn[1] = tangent;
+		o.btn[2] = worldNormal;
+    #ifdef _LIGHTING_MODEL
+			o.eyeVec.xyz = NormalizePerVertexNormal(o.worldPos.xyz - _WorldSpaceCameraPos);
+			o.ambientOrLightmapUV = VertexGIForward(v, o.worldPos, o.btn[2]);
+    #else
+			o.objPos = v.vertex;
+			o.objNormal = v.normal;
+    #endif
+    #if !defined(VOLUMETRIC_YES) && !defined (PROJECTION_YES)
+				UNITY_TRANSFER_SHADOW(o, o.uv);
+
+    #endif
+    #else
+		o.color = v.color;
+    #endif
+    #endif
+
+    ////////////////////////////////////////END AUDIOLINK VERTEX//////////////////////////////////////////////////////////////////////
+
+    return o;
+}
+
+v2f vertFixture(appdata v)
+{
+    v2f o;
+    UNITY_SETUP_INSTANCE_ID(v);
+    UNITY_INITIALIZE_OUTPUT(v2f, o); //DON'T INITIALIZE OR IT WILL BREAK PROJECTION
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+    UNITY_TRANSFER_INSTANCE_ID(v, o);
+
+    ////////////////////////////////////////START DMX VERTEX//////////////////////////////////////////////////////////////////////
+    #ifdef VRSL_DMX
+        uint dmx = getDMXChannel();
+        half oscConeWidth = getDMXConeWidth(dmx);
+        half oscPanValue = GetPanValue(dmx);
+        half oscTiltValue = GetTiltValue(dmx);
+
+
+        v.vertex = CalculateConeWidth(v, v.vertex, oscConeWidth, dmx);
+        v.vertex = CalculateProjectionScaleRange(v, v.vertex, _ProjectionRange);
+
+        //calculate rotations for verts
+        v.vertex = calculateRotations(v, v.vertex, 0, oscPanValue, oscTiltValue);
+
+        //calculate rotations for normals, cast to half4 first with 0 as w
+        half4 newNormals = half4(v.normal.x, v.normal.y, v.normal.z, 0);
+        newNormals = calculateRotations(v, newNormals, 1, oscPanValue, oscTiltValue);
+        v.normal = newNormals.xyz;
+
+        //calculate rotations for tangents, cast to half4 first with 0 as w
+        // half4 newTangent = half4(v.tangent.x, v.tangent.y, v.tangent.z, 0);
+        // newTangent = calculateRotations(v, newTangent, 1, oscPanValue, oscTiltValue);
+        // v.tangent = newTangent.xyz;
+
+        #if defined(FIXTURE_SHADOWCAST)
+		    //o.pos = UnityObjectToClipPos(v.vertex);
+		    o.pos = UnityClipSpaceShadowCasterPos(v.vertex, v.normal);
+		    o.pos = UnityApplyLinearShadowBias(o.pos);
+		    //o.normal = v.normal;
+		    //TRANSFER_SHADOW_CASTER_NORMALOFFSET(o);
+		    return o;
+        #endif
+
+        //original surface shader related code
+        half3 worldNormal = UnityObjectToWorldNormal(v.normal);
+        half3 tangent = UnityObjectToWorldDir(v.tangent);
+        half3 bitangent = cross(tangent, worldNormal);
+
+
+        #if !defined(FIXTURE_SHADOWCAST)
+            o.pos = UnityObjectToClipPos(v.vertex);
+            o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+        #endif
+
+        #if defined(UNITY_PASS_FORWARDBASE)
+            o.uv1 = v.uv1;
+            o.uv2 = v.uv2;
+        #endif
+
+
+        #if !defined(UNITY_PASS_SHADOWCASTER)
+            o.color = v.color;
+            o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+
+            o.intensityStrobe = half2(GetDMXIntensity(dmx, 1.0), GetStrobeOutput(dmx));
+            o.rgbColor = GetDMXColor(dmx);
+            o.btn[0] = bitangent;
+            o.btn[1] = tangent;
+            o.btn[2] = worldNormal;
+            #ifdef _LIGHTING_MODEL
+			    o.eyeVec.xyz = NormalizePerVertexNormal(o.worldPos.xyz - _WorldSpaceCameraPos);
+			    o.ambientOrLightmapUV = VertexGIForward(v, o.worldPos, o.btn[2]);
+            #else
+                o.objPos = v.vertex;
+                o.objNormal = v.normal;
+            #endif
+            UNITY_TRANSFER_SHADOW(o, o.uv);
+        #else
+			o.color = v.color;
+        #endif
+    #endif
+    ////////////////////////////////////////END DMX VERTEX//////////////////////////////////////////////////////////////////////
+
+
+    ////////////////////////////////////////START AUDIOLINK VERTEX//////////////////////////////////////////////////////////////////////
+
+    #ifdef VRSL_AUDIOLINK
+		v.vertex = CalculateConeWidth(v, v.vertex, getConeWidth());
+		v.vertex = CalculateProjectionScaleRange(v, v.vertex, _ProjectionRange);
+
+
+		//calculate rotations for normals, cast to half4 first with 0 as w
+		half4 newNormals = half4(v.normal.x, v.normal.y, v.normal.z, 0);
+		//newNormals = calculateRotations(v, newNormals, 1);
+		v.normal = newNormals.xyz;
+
+		//calculate rotations for tangents, cast to half4 first with 0 as w
+		half4 newTangent = half4(v.tangent.x, v.tangent.y, v.tangent.z, 0);
+		//newTangent = calculateRotations(v, newTangent, 1);
+		v.tangent = newTangent.xyz;
+
+		//original surface shader related code
+		half3 worldNormal = UnityObjectToWorldNormal(v.normal);
+		half3 tangent = UnityObjectToWorldDir(v.tangent);
+		half3 bitangent = cross(tangent, worldNormal);
+
+
+			o.pos = UnityObjectToClipPos(v.vertex);
+			o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+
+		
+    #if defined(UNITY_PASS_FORWARDBASE)
+		o.uv1 = v.uv1;
+		o.uv2 = v.uv2;
+    #endif
+
+
+		o.color = v.color;
+		o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+		o.btn[0] = bitangent;
+		o.btn[1] = tangent;
+		o.btn[2] = worldNormal;
+    #ifdef _LIGHTING_MODEL
+		o.eyeVec.xyz = NormalizePerVertexNormal(o.worldPos.xyz - _WorldSpaceCameraPos);
+		o.ambientOrLightmapUV = VertexGIForward(v, o.worldPos, o.btn[2]);
+    #else
+		o.objPos = v.vertex;
+		o.objNormal = v.normal;
+    #endif
+		UNITY_TRANSFER_SHADOW(o, o.uv);
+
+    #else
+        o.color = v.color;
+    #endif
+
+    ////////////////////////////////////////END AUDIOLINK VERTEX//////////////////////////////////////////////////////////////////////
+
+    return o;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////START FRAG SHADERS//////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+#if defined(VOLUMETRIC_YES)
+fixed4 frag (v2f i, fixed facePos : VFACE) : SV_Target
+{
+	return VolumetricLightingBRDF(i, facePos);
+}
+#endif
+#if !defined(VOLUMETRIC_YES)
+fixed4 frag(v2f i) : SV_Target
+{
+    //Return only this if in the shadowcaster
+    #if defined(UNITY_PASS_SHADOWCASTER) && !defined(FIXTURE_SHADOWCAST)
+	if(i.color.r > 0 && i.color.b > 0)
+	{
+		discard;
+		return half4(0,0,0,0);		
+	}
+	else
+	{
+		SHADOW_CASTER_FRAGMENT(i);
+	}
+
+	// #elif defined (VOLUMETRIC_YES)
+	// 	return VolumetricLightingBRDF(i);
+    #elif defined (PROJECTION_YES)
+		return ProjectionFrag(i);
+
+    #elif defined (FIXTURE_SHADOWCAST)
+		SHADOW_CASTER_FRAGMENT(i);
+    
+    #else
+    return CustomStandardLightingBRDF(i);
+    #endif
+}
+#endif

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-Vertex-URP.cginc.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-Vertex-URP.cginc.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8081d931d3ee49f6a631aff320bcf9d1
+timeCreated: 1746510237

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-VolumetricMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-VolumetricMesh.shader
@@ -142,6 +142,96 @@
 		//[KeywordEnum(None, UseDNTexture)] _DNEnabler ("Enable Depth Normal Texture", Float) = 0
 
 	}
+    SubShader
+    {
+
+        Tags
+        {
+            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent""RenderingPipeline" = "UniversalPipeline"
+        }
+        //Volumetric Pass
+
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Blend One [_BlendDst]
+            Cull Off
+            ZWrite Off
+            Lighting Off
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            //#pragma multi_compile_fog
+            #pragma multi_compile_instancing
+            #pragma instancing_options assumeuniformscaling
+            #pragma multi_compile_local _ _MAGIC_NOISE_ON_HIGH
+            #pragma multi_compile_local _ _MAGIC_NOISE_ON_MED
+            #pragma multi_compile_local _ _USE_DEPTH_LIGHT
+            #pragma multi_compile_local _ _POTATO_MODE_ON
+            #pragma multi_compile_local _ _HQ_MODE
+            #pragma multi_compile_local _ _2D_NOISE_ON
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #define VOLUMETRIC_YES //To identify the pass in the vert/frag
+            #define VRSL_DMX
+
+            #include "UnityCG.cginc"
+            #include "../Shared/VRSL-Defines.cginc" //Property Defines are here
+            #include "../Shared/VRSL-DMXFunctions.cginc" //Custom Functions
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float4 color : COLOR;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float2 uv2 : TEXCOORD3;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                centroid float2 uv : TEXCOORD0;
+                float blindingEffect : TEXCOORD1;
+                float4 worldPos : TEXCOORD2;
+                float3 currentForward : TEXCOORD3;
+                float2 camAngleCamfade : TEXCOORD5;
+                float4 screenPos : TEXCOORD6;
+                float4 pos : SV_POSITION;
+                //float3 objPos : TEXCOORD7;
+                centroid float3 objNormal : TEXCOORD8;
+                float2 stripeInfo : TEXCOORD9;
+                float coneWidth : TEXCOORD10;
+                //float2 uvClone : TEXCOORD10;
+                //float3 norm : TEXCOORD11;
+                float2 uv2 : TEXCOORD13;
+                float4 worldDirection : TEXCOORD14;
+                float4 intensityStrobeGOBOSpinSpeed : TEXCOORD15;
+                float4 rgbColor : TEXCOORD16;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "VRSL-StandardMover-VolumetricFrag.cginc" //Fragment Shader is here
+            #include "VRSL-StandardMover-Vertex.cginc" //Vertex Shader is here
+            ENDCG
+        }
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
 		SubShader
 	{
 		

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-FixtureMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-FixtureMesh.shader
@@ -53,6 +53,285 @@
 		_DecorativeEmissiveMapStrength("Decorative Emissive Map Strength", Range(0,1)) = 0
 
 	}
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderingPipeline" = "UniversalPipeline"
+        }
+
+        Pass
+        {
+            Name "UniversalForward"
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_fwdbase
+            #pragma multi_compile_instancing
+            #pragma shader_feature_local _LIGHTING_MODEL
+            //REMOVE THIS WHEN FINISHED DEBUGGING
+            //#pragma target 4.5
+
+            #define GEOMETRY
+
+            #ifndef UNITY_PASS_FORWARDBASE
+            #define UNITY_PASS_FORWARDBASE
+            #endif
+
+            #define FIXTURE_EMIT
+            #define VRSL_DMX
+            #define WASH
+            //DEBUGGING BUFFER
+
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "AutoLight.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float4 color : COLOR;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float3 btn[3] : TEXCOORD3; //TEXCOORD2, TEXCOORD3 | bitangent, tangent, worldNormal
+                float3 worldPos : TEXCOORD6;
+                #ifdef _LIGHTING_MODEL
+			        UNITY_LIGHTING_COORDS(7,8)
+			        float4 eyeVec : TEXCOORD12;
+			        half4 ambientOrLightmapUV : TEXCOORD13;
+                #else
+                float3 objPos : TEXCOORD7;
+                float3 objNormal : TEXCOORD8;
+                float4 _ShadowCoord : TEXCOORD11;
+                #endif
+                float4 color : COLOR;
+                float2 intensityStrobe : TEXCOORD9;
+                float4 rgbColor : TEXCOORD10;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "../Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-DMXFunctions.cginc"
+            #include "../Shared/VRSL-LightingFunctions.cginc"
+            #include "../Shared/VRSL-StandardLighting.cginc"
+            #include "VRSL-StandardMover-Vertex.cginc"
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags
+            {
+                "LightMode"="ShadowCaster"
+            }
+
+            CGPROGRAM
+            #define FIXTURE_SHADOWCAST
+            #define VRSL_DMX
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_shadowcaster
+            #pragma multi_compile_instancing
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float4 color : COLOR;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float3 normal: TEXCOORD0;
+                float4 color: COLOR;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "../Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-DMXFunctions.cginc"
+            #include "VRSL-StandardMover-Vertex.cginc"
+            ENDCG
+        }
+
+        // DepthOnly and DepthNormals MUST utilize exact same rotations as the forward pass for vertex rotation to have rendering continuity
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_fwdbase
+            #pragma multi_compile_instancing
+            #pragma shader_feature_local _LIGHTING_MODEL
+            //REMOVE THIS WHEN FINISHED DEBUGGING
+            //#pragma target 4.5
+
+            #define GEOMETRY
+
+            #ifndef UNITY_PASS_FORWARDBASE
+            #define UNITY_PASS_FORWARDBASE
+            #endif
+
+            #define FIXTURE_EMIT
+            #define VRSL_DMX
+            #define WASH
+
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "AutoLight.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float4 color : COLOR;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float3 btn[3] : TEXCOORD3; //TEXCOORD2, TEXCOORD3 | bitangent, tangent, worldNormal
+                float3 worldPos : TEXCOORD6;
+                #ifdef _LIGHTING_MODEL
+			        UNITY_LIGHTING_COORDS(7,8)
+			        float4 eyeVec : TEXCOORD12;
+			        half4 ambientOrLightmapUV : TEXCOORD13;
+                #else
+                float3 objPos : TEXCOORD7;
+                float3 objNormal : TEXCOORD8;
+                float4 _ShadowCoord : TEXCOORD11;
+                #endif
+                float4 color : COLOR;
+                float2 intensityStrobe : TEXCOORD9;
+                float4 rgbColor : TEXCOORD10;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "../Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-DMXFunctions.cginc"
+            #include "../Shared/VRSL-LightingFunctions.cginc"
+            #include "../Shared/VRSL-StandardLighting.cginc"
+            #include "VRSL-StandardMover-Vertex.cginc"
+            ENDCG
+        }
+
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_fwdbase
+            #pragma multi_compile_instancing
+            #pragma shader_feature_local _LIGHTING_MODEL
+            //REMOVE THIS WHEN FINISHED DEBUGGING
+            //#pragma target 4.5
+
+            #define GEOMETRY
+
+            #ifndef UNITY_PASS_FORWARDBASE
+            #define UNITY_PASS_FORWARDBASE
+            #endif
+
+            #define FIXTURE_EMIT
+            #define VRSL_DMX
+            #define WASH
+            //DEBUGGING BUFFER
+
+            #include "UnityCG.cginc"
+            #include "Lighting.cginc"
+            #include "AutoLight.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float4 color : COLOR;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float3 btn[3] : TEXCOORD3; //TEXCOORD2, TEXCOORD3 | bitangent, tangent, worldNormal
+                float3 worldPos : TEXCOORD6;
+                #ifdef _LIGHTING_MODEL
+			        UNITY_LIGHTING_COORDS(7,8)
+			        float4 eyeVec : TEXCOORD12;
+			        half4 ambientOrLightmapUV : TEXCOORD13;
+                #else
+                float3 objPos : TEXCOORD7;
+                float3 objNormal : TEXCOORD8;
+                float4 _ShadowCoord : TEXCOORD11;
+                #endif
+                float4 color : COLOR;
+                float2 intensityStrobe : TEXCOORD9;
+                float4 rgbColor : TEXCOORD10;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "../Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-DMXFunctions.cginc"
+            #include "../Shared/VRSL-LightingFunctions.cginc"
+            #include "../Shared/VRSL-StandardLighting.cginc"
+            #include "VRSL-StandardMover-Vertex.cginc"
+            ENDCG
+        }
+
+    }
+	
 		SubShader
 	{
 		
@@ -114,7 +393,7 @@ RWStructuredBuffer<float4> buffer4 : register(u2);
 		#else
 			float3 objPos : TEXCOORD7;
 			float3 objNormal : TEXCOORD8;
-			SHADOW_COORDS(11)
+	        float4 _ShadowCoord : TEXCOORD11;
 		#endif
 		float4 color : COLOR;
 		float2 intensityStrobe : TEXCOORD9;
@@ -163,6 +442,7 @@ RWStructuredBuffer<float4> buffer4 : register(u2);
 		{
 			float4 pos : SV_POSITION;
 			float3 normal: TEXCOORD0;
+		    float4 color : COLOR;
 			UNITY_VERTEX_INPUT_INSTANCE_ID
 			UNITY_VERTEX_OUTPUT_STEREO
 			//SHADOW_COORDS(11)

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-ProjectionMesh.shader
@@ -145,6 +145,97 @@
 
 
 	}
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+        }
+
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Cull Front
+            Ztest GEqual
+            ZWrite Off
+            Blend DstColor [_BlendDst]
+            BlendOp Add
+            Offset -1, -1
+            Lighting Off
+
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma shader_feature_local _MULTISAMPLEDEPTH
+            //#pragma multi_compile_fog
+            #pragma multi_compile_instancing
+            #pragma instancing_options assumeuniformscaling
+            //#pragma multi_compile _DNENABLER_NONE _DNENABLER_USEDNTEXTURE
+            #define PROJECTION_YES //To identify the pass in the vert/frag shaders
+            #define PROJECTION_MOVER
+            #define WASH
+            #define VRSL_DMX
+
+            #include "UnityCG.cginc"
+            #include "../Shared/VRSL-Defines.cginc" //Property Defines are here
+
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float3 texcoord : TEXCOORD1;
+                float4 color : COLOR;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float4 projectionorigin : TEXCOORD2;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 ray : TEXCOORD2;
+                float4 screenPos : TEXCOORD4;
+                float4 color : COLOR;
+                float3 normal : TEXCOORD3;
+                float2 dmx: TEXCOORD10;
+                float4 projectionorigin : TEXCOORD5;
+                float4 worldDirection : TEXCOORD6;
+                float4 worldPos : TEXCOORD7;
+                float3 viewDir : TEXCOORD8;
+                float3 intensityStrobeWidth : TEXCOORD9;
+                float4 goboPlusSpinPanTilt : TEXCOORD11;
+                float4 rgbColor : TEXCOORD12;
+                float4 emissionColor : TEXCOORD13;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "../Shared/VRSL-DMXFunctions.cginc" //Custom Functions
+            #include "VRSL-StandardMover-ProjectionFrag.cginc" //Fragment Shader is here
+            #include "VRSL-StandardMover-Vertex.cginc" //Vertex Shader is here
+            ENDCG
+
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
 		SubShader
 	{
 		

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-VolumetricMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-VolumetricMesh.shader
@@ -140,6 +140,94 @@
 		//[KeywordEnum(None, UseDNTexture)] _DNEnabler ("Enable Depth Normal Texture", Float) = 0
 
 	}
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+        }
+        //Volumetric Pass
+
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Blend One [_BlendDst]
+            Cull Off
+            ZWrite [_ZWrite]
+            Lighting Off
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            //#pragma multi_compile_fog
+            #pragma multi_compile_instancing
+            #pragma instancing_options assumeuniformscaling
+            #pragma multi_compile_local _ _MAGIC_NOISE_ON_HIGH
+            #pragma multi_compile_local _ _MAGIC_NOISE_ON_MED
+            #pragma multi_compile_local _ _USE_DEPTH_LIGHT
+            #pragma multi_compile_local _ _POTATO_MODE_ON
+            #pragma multi_compile_local _ _HQ_MODE
+            #pragma multi_compile_local _ _2D_NOISE_ON
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #define VOLUMETRIC_YES //To identify the pass in the vert/frag
+            #define WASH
+            #define VRSL_DMX
+            #include "UnityCG.cginc"
+            #include "../Shared/VRSL-Defines.cginc" //Property Defines are here
+            float3 thisIsAChange;
+            #include "../Shared/VRSL-DMXFunctions.cginc" //Custom Functions
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float4 color : COLOR;
+                float3 normal : NORMAL;
+                float3 tangent : TANGENT;
+                float2 uv2 : TEXCOORD3;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                centroid float2 uv : TEXCOORD0;
+                float blindingEffect : TEXCOORD1;
+                float4 worldPos : TEXCOORD2;
+                //float4 color : TEXCOORD3;
+                float3 currentForward : TEXCOORD3;
+                float2 camAngleCamfade : TEXCOORD5;
+                float4 screenPos : TEXCOORD6;
+                float4 pos : SV_POSITION;
+                //float3 objPos : TEXCOORD7;
+                centroid float3 objNormal : TEXCOORD8;
+                float2 stripeInfo : TEXCOORD9;
+                float coneWidth : TEXCOORD10;
+                //float2 uvClone : TEXCOORD10;
+                //float3 norm : TEXCOORD11;
+                float2 uv2 : TEXCOORD13;
+                float4 worldDirection : TEXCOORD14;
+                float4 intensityStrobeGOBOSpinSpeed : TEXCOORD15;
+                float4 rgbColor : TEXCOORD16;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "VRSL-StandardMover-VolumetricFrag.cginc" //Fragment Shader is here
+            #include "VRSL-StandardMover-Vertex.cginc" //Vertex Shader is here
+            ENDCG
+        }
+    }
+
 		SubShader
 	{
 		

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/GenericUnlitTexture-Linear.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/GenericUnlitTexture-Linear.shader
@@ -8,6 +8,107 @@
     }
     SubShader
     {
+        Tags
+        {
+            "RenderType"="Opaque" "RenderingPipeline"="UniversalPipeline"
+        }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            // make fog work
+            #pragma multi_compile_fog
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                UNITY_FOG_COORDS(1)
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _EmissionMap;
+            float4 _EmissionMap_ST;
+            int _IsAVProInput;
+            float _TargetAspectRatio;
+            float4 _EmissionMap_TexelSize;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _EmissionMap);
+                UNITY_TRANSFER_FOG(o, o.vertex);
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                float2 uv = i.uv;
+                float2 emissionRes = _EmissionMap_TexelSize.zw;
+
+                float currentAspectRatio = emissionRes.x / emissionRes.y;
+
+                float visibility = 1.0;
+
+                // If the aspect ratio does not match the target ratio, then we fit the UVs to maintain the aspect ratio while fitting the range 0-1
+                if (abs(currentAspectRatio - _TargetAspectRatio) > 0.001)
+                {
+                    float2 normalizedVideoRes = float2(emissionRes.x / _TargetAspectRatio, emissionRes.y);
+                    float2 correctiveScale;
+
+                    // Find which axis is greater, we will clamp to that
+                    if (normalizedVideoRes.x > normalizedVideoRes.y)
+                        correctiveScale = float2(1, normalizedVideoRes.y / normalizedVideoRes.x);
+                    else
+                        correctiveScale = float2(normalizedVideoRes.x / normalizedVideoRes.y, 1);
+
+                    uv = ((uv - 0.5) / correctiveScale) + 0.5;
+
+                    // Antialiasing on UV clipping
+                    float2 uvPadding = (1 / emissionRes) * 0.1;
+                    float2 uvfwidth = fwidth(uv.xy);
+                    float2 maxFactor = smoothstep(uvfwidth + uvPadding + 1, uvPadding + 1, uv.xy);
+                    float2 minFactor = smoothstep(-uvfwidth - uvPadding, -uvPadding, uv.xy);
+
+                    visibility = maxFactor.x * maxFactor.y * minFactor.x * minFactor.y;
+
+                    //if (any(uv <= 0) || any(uv >= 1))
+                    //    return float3(0, 0, 0);
+                }
+                // sample the texture
+                float3 texColor = tex2D(_EmissionMap, _IsAVProInput ? float2(uv.x, 1 - uv.y) : uv).rgb;
+
+                if (!_IsAVProInput)
+                {
+                    texColor = LinearToGammaSpace(texColor);
+                }
+                // if (_IsAVProInput)
+                //     texColor = pow(texColor, 2.2f);
+                // apply fog
+                UNITY_APPLY_FOG(i.fogCoord, float4(texColor,1));
+                return float4(texColor, 1);
+            }
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Unlit/DepthOnly"
+        UsePass "Universal Render Pipeline/Unlit/DepthNormals"
+    }
+
+    SubShader
+    {
         Tags { "RenderType"="Opaque" }
         LOD 100
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/GenericUnlitTexture.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/GenericUnlitTexture.shader
@@ -8,6 +8,102 @@
     }
     SubShader
     {
+        Tags
+        {
+            "RenderType"="Opaque" "RenderingPipeline" = "UniversalPipeline"
+        }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            // make fog work
+            #pragma multi_compile_fog
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                UNITY_FOG_COORDS(1)
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _EmissionMap;
+            float4 _EmissionMap_ST;
+            int _IsAVProInput;
+            float _TargetAspectRatio;
+            float4 _EmissionMap_TexelSize;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _EmissionMap);
+                UNITY_TRANSFER_FOG(o, o.vertex);
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                float2 uv = i.uv;
+                float2 emissionRes = _EmissionMap_TexelSize.zw;
+
+                float currentAspectRatio = emissionRes.x / emissionRes.y;
+
+                float visibility = 1.0;
+
+                // If the aspect ratio does not match the target ratio, then we fit the UVs to maintain the aspect ratio while fitting the range 0-1
+                if (abs(currentAspectRatio - _TargetAspectRatio) > 0.001)
+                {
+                    float2 normalizedVideoRes = float2(emissionRes.x / _TargetAspectRatio, emissionRes.y);
+                    float2 correctiveScale;
+
+                    // Find which axis is greater, we will clamp to that
+                    if (normalizedVideoRes.x > normalizedVideoRes.y)
+                        correctiveScale = float2(1, normalizedVideoRes.y / normalizedVideoRes.x);
+                    else
+                        correctiveScale = float2(normalizedVideoRes.x / normalizedVideoRes.y, 1);
+
+                    uv = ((uv - 0.5) / correctiveScale) + 0.5;
+
+                    // Antialiasing on UV clipping
+                    float2 uvPadding = (1 / emissionRes) * 0.1;
+                    float2 uvfwidth = fwidth(uv.xy);
+                    float2 maxFactor = smoothstep(uvfwidth + uvPadding + 1, uvPadding + 1, uv.xy);
+                    float2 minFactor = smoothstep(-uvfwidth - uvPadding, -uvPadding, uv.xy);
+
+                    visibility = maxFactor.x * maxFactor.y * minFactor.x * minFactor.y;
+
+                    //if (any(uv <= 0) || any(uv >= 1))
+                    //    return float3(0, 0, 0);
+                }
+                // sample the texture
+                float3 texColor = tex2D(_EmissionMap, _IsAVProInput ? float2(uv.x, 1 - uv.y) : uv).rgb;
+                if (_IsAVProInput)
+                    texColor = pow(texColor, 2.2f);
+                // apply fog
+                UNITY_APPLY_FOG(i.fogCoord, float4(texColor,1));
+                return float4(texColor, 1);
+            }
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Unlit/DepthOnly"
+        UsePass "Universal Render Pipeline/Unlit/DepthNormals"
+    }
+
+    SubShader
+    {
         Tags { "RenderType"="Opaque" }
         LOD 100
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Standard.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Standard.shader
@@ -1,0 +1,686 @@
+Shader "VRSL/Other/Standard"
+{
+    Properties
+    {
+        // URP
+
+        // Specular vs Metallic workflow
+        _WorkflowMode("WorkflowMode", Float) = 1.0
+
+        [MainTexture] _BaseMap("Albedo", 2D) = "white" {}
+        [MainColor] _BaseColor("Color", Color) = (1,1,1,1)
+
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+
+        _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5
+        _SmoothnessTextureChannel("Smoothness texture channel", Float) = 0
+
+        _Metallic("Metallic", Range(0.0, 1.0)) = 0.0
+        _MetallicGlossMap("Metallic", 2D) = "white" {}
+
+        _SpecColor("Specular", Color) = (0.2, 0.2, 0.2)
+        _SpecGlossMap("Specular", 2D) = "white" {}
+
+        [ToggleOff] _SpecularHighlights("Specular Highlights", Float) = 1.0
+        [ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
+
+        _BumpScale("Scale", Float) = 1.0
+        _BumpMap("Normal Map", 2D) = "bump" {}
+
+        _Parallax("Scale", Range(0.005, 0.08)) = 0.005
+        _ParallaxMap("Height Map", 2D) = "black" {}
+
+        _OcclusionStrength("Strength", Range(0.0, 1.0)) = 1.0
+        _OcclusionMap("Occlusion", 2D) = "white" {}
+
+        [HDR] _EmissionColor("Color", Color) = (0,0,0)
+        _EmissionMap("Emission", 2D) = "white" {}
+
+        _DetailMask("Detail Mask", 2D) = "white" {}
+        _DetailAlbedoMapScale("Scale", Range(0.0, 2.0)) = 1.0
+        _DetailAlbedoMap("Detail Albedo x2", 2D) = "linearGrey" {}
+        _DetailNormalMapScale("Scale", Range(0.0, 2.0)) = 1.0
+        [Normal] _DetailNormalMap("Normal Map", 2D) = "bump" {}
+
+        // SRP batching compatibility for Clear Coat (Not used in Lit)
+        [HideInInspector] _ClearCoatMask("_ClearCoatMask", Float) = 0.0
+        [HideInInspector] _ClearCoatSmoothness("_ClearCoatSmoothness", Float) = 0.0
+
+        // Blending state
+        _Surface("__surface", Float) = 0.0
+        _Blend("__blend", Float) = 0.0
+        _Cull("__cull", Float) = 2.0
+        [ToggleUI] _AlphaClip("__clip", Float) = 0.0
+        [HideInInspector] _SrcBlend("__src", Float) = 1.0
+        [HideInInspector] _DstBlend("__dst", Float) = 0.0
+        [HideInInspector] _SrcBlendAlpha("__srcA", Float) = 1.0
+        [HideInInspector] _DstBlendAlpha("__dstA", Float) = 0.0
+        [HideInInspector] _ZWrite("__zw", Float) = 1.0
+        [HideInInspector] _BlendModePreserveSpecular("_BlendModePreserveSpecular", Float) = 1.0
+        [HideInInspector] _AlphaToMask("__alphaToMask", Float) = 0.0
+        [HideInInspector] _AddPrecomputedVelocity("_AddPrecomputedVelocity", Float) = 0.0
+
+        [ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
+        // Editmode props
+        _QueueOffset("Queue offset", Float) = 0.0
+
+        // ObsoleteProperties
+        [HideInInspector] _MainTex("BaseMap", 2D) = "white" {}
+        [HideInInspector] _Color("Base Color", Color) = (1, 1, 1, 1)
+        [HideInInspector] _GlossMapScale("Smoothness", Float) = 0.0
+        [HideInInspector] _Glossiness("Smoothness", Float) = 0.0
+        [HideInInspector] _GlossyReflections("EnvironmentReflections", Float) = 0.0
+
+        [HideInInspector][NoScaleOffset]unity_Lightmaps("unity_Lightmaps", 2DArray) = "" {}
+        [HideInInspector][NoScaleOffset]unity_LightmapsInd("unity_LightmapsInd", 2DArray) = "" {}
+        [HideInInspector][NoScaleOffset]unity_ShadowMasks("unity_ShadowMasks", 2DArray) = "" {}
+
+        // BIRP specific
+        [Enum(UV0,0,UV1,1)] _UVSec ("UV Set for secondary textures", Float) = 0
+        // Blending state
+        [HideInInspector] _Mode ("__mode", Float) = 0.0
+    }
+
+    // URP Lit 
+    SubShader
+    {
+        // Universal Pipeline tag is required. If Universal render pipeline is not set in the graphics settings
+        // this Subshader will fail. One can add a subshader below or fallback to Standard built-in to make this
+        // material work with both Universal Render Pipeline and Builtin Unity Pipeline
+        PackageRequirements{ "com.unity.render-pipelines.universal" }
+        Tags
+        {
+            "RenderType" = "Opaque"
+            "RenderPipeline" = "UniversalPipeline"
+            "UniversalMaterialType" = "Lit"
+            "IgnoreProjector" = "True"
+        }
+        LOD 300
+
+        // ------------------------------------------------------------------
+        //  Forward pass. Shades all light in a single pass. GI + emission + Fog
+        Pass
+        {
+            // Lightmode matches the ShaderPassName set in UniversalRenderPipeline.cs. SRPDefaultUnlit and passes with
+            // no LightMode tag are also rendered by Universal Render Pipeline
+            Name "ForwardLit"
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            Blend[_SrcBlend][_DstBlend], [_SrcBlendAlpha][_DstBlendAlpha]
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+            AlphaToMask[_AlphaToMask]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex LitPassVertex
+            #pragma fragment LitPassFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local _PARALLAXMAP
+            #pragma shader_feature_local _RECEIVE_SHADOWS_OFF
+            #pragma shader_feature_local _ _DETAIL_MULX2 _DETAIL_SCALED
+            #pragma shader_feature_local_fragment _SURFACE_TYPE_TRANSPARENT
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ _ALPHAPREMULTIPLY_ON _ALPHAMODULATE_ON
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local_fragment _METALLICSPECGLOSSMAP
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+            #pragma shader_feature_local_fragment _OCCLUSIONMAP
+            #pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+            #pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+            #pragma shader_feature_local_fragment _SPECULAR_SETUP
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ EVALUATE_SH_MIXED EVALUATE_SH_VERTEX
+            #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _REFLECTION_PROBE_BLENDING
+            #pragma multi_compile_fragment _ _REFLECTION_PROBE_BOX_PROJECTION
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT _SHADOWS_SOFT_LOW _SHADOWS_SOFT_MEDIUM _SHADOWS_SOFT_HIGH
+            #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile_fragment _ _LIGHT_COOKIES
+            #pragma multi_compile _ _LIGHT_LAYERS
+            #pragma multi_compile _ _FORWARD_PLUS
+
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+            #pragma multi_compile _ SHADOWS_SHADOWMASK
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
+            #pragma multi_compile _ USE_LEGACY_LIGHTMAPS
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fog
+            #pragma multi_compile_fragment _ DEBUG_DISPLAY
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma instancing_options renderinglayer
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl"
+            #else// Minimal vertex function
+            // #pragma vert Vertex
+            // #pragma frag Fragment
+            float4 LitPassVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 LitPassFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags
+            {
+                "LightMode" = "ShadowCaster"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex ShadowPassVertex
+            #pragma fragment ShadowPassFragment
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            // This is used during shadow map generation to differentiate between directional and punctual light shadows, as they use different formulas to apply Normal Bias
+            #pragma multi_compile_vertex _ _CASTING_PUNCTUAL_LIGHT_SHADOW
+
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/ShadowCasterPass.hlsl"
+            #else
+            // #pragma vert Vertex
+            // #pragma frag Fragment
+            float4 ShadowPassVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 ShadowPassFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            // Lightmode matches the ShaderPassName set in UniversalRenderPipeline.cs. SRPDefaultUnlit and passes with
+            // no LightMode tag are also rendered by Universal Render Pipeline
+            Name "GBuffer"
+            Tags
+            {
+                "LightMode" = "UniversalGBuffer"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite[_ZWrite]
+            ZTest LEqual
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 4.5
+
+            // Deferred Rendering Path does not support the OpenGL-based graphics API:
+            // Desktop OpenGL, OpenGL ES 3.0, WebGL 2.0.
+            #pragma exclude_renderers gles3 glcore
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex LitGBufferPassVertex
+            #pragma fragment LitGBufferPassFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            //#pragma shader_feature_local_fragment _ALPHAPREMULTIPLY_ON
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local_fragment _METALLICSPECGLOSSMAP
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+            #pragma shader_feature_local_fragment _OCCLUSIONMAP
+            #pragma shader_feature_local _PARALLAXMAP
+            #pragma shader_feature_local _ _DETAIL_MULX2 _DETAIL_SCALED
+
+            #pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+            #pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+            #pragma shader_feature_local_fragment _SPECULAR_SETUP
+            #pragma shader_feature_local _RECEIVE_SHADOWS_OFF
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            //#pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            //#pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _REFLECTION_PROBE_BLENDING
+            #pragma multi_compile_fragment _ _REFLECTION_PROBE_BOX_PROJECTION
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT _SHADOWS_SOFT_LOW _SHADOWS_SOFT_MEDIUM _SHADOWS_SOFT_HIGH
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile_fragment _ _RENDER_PASS_ENABLED
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+            #pragma multi_compile _ SHADOWS_SHADOWMASK
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
+            #pragma multi_compile _ USE_LEGACY_LIGHTMAPS
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fragment _ _GBUFFER_NORMALS_OCT
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma instancing_options renderinglayer
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitGBufferPass.hlsl"
+            #else
+            // #pragma vert Vertex
+            // #pragma frag Fragment
+            float4 LitGBufferPassVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 LitGBufferPassFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+            ColorMask R
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex DepthOnlyVertex
+            #pragma fragment DepthOnlyFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthOnlyPass.hlsl"
+            #else
+            // #pragma vert Vertex
+            // #pragma frag Fragment
+            float4 DepthOnlyVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 DepthOnlyFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        // This pass is used when drawing to a _CameraNormalsTexture texture
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex DepthNormalsVertex
+            #pragma fragment DepthNormalsFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local _PARALLAXMAP
+            #pragma shader_feature_local _ _DETAIL_MULX2 _DETAIL_SCALED
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitDepthNormalsPass.hlsl"
+            #else
+            float4 DepthNormalsVertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 DepthNormalsFragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        // This pass it not used during regular rendering, only for lightmap baking.
+        Pass
+        {
+            Name "Meta"
+            Tags
+            {
+                "LightMode" = "Meta"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex UniversalVertexMeta
+            #pragma fragment UniversalFragmentMetaLit
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _SPECULAR_SETUP
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local_fragment _METALLICSPECGLOSSMAP
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+            #pragma shader_feature_local _ _DETAIL_MULX2 _DETAIL_SCALED
+            #pragma shader_feature_local_fragment _SPECGLOSSMAP
+            #pragma shader_feature EDITOR_VISUALIZATION
+
+
+            #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitMetaPass.hlsl"
+            #else
+            float4 UniversalVertexMeta(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 UniversalFragmentMetaLit() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "Universal2D"
+            Tags
+            {
+                "LightMode" = "Universal2D"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            Blend[_SrcBlend][_DstBlend]
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex vert
+            #pragma fragment frag
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ALPHAPREMULTIPLY_ON
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/Utils/Universal2D.hlsl"
+            #else
+            #pragma vert Vertex
+            #pragma frag Fragment
+            float4 Vertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 Fragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "MotionVectors"
+            Tags
+            {
+                "LightMode" = "MotionVectors"
+            }
+            ColorMask RG
+
+            HLSLPROGRAM
+            // #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
+            #else
+            #pragma vert Vertex
+            #pragma frag Fragment
+            float4 Vertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 Fragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "XRMotionVectors"
+            Tags
+            {
+                "LightMode" = "XRMotionVectors"
+            }
+            ColorMask RGBA
+
+            // Stencil write for obj motion pixels
+            Stencil
+            {
+                WriteMask 1
+                Ref 1
+                Comp Always
+                Pass Replace
+            }
+
+            HLSLPROGRAM
+            // #pragma shader_feature UNIVERSAL_RENDER_PIPELINE
+            #if defined(UNIVERSAL_RENDER_PIPELINE)
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+            #define APLICATION_SPACE_WARP_MOTION 1
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
+            #else
+            #pragma vert Vertex
+            #pragma frag Fragment
+            float4 Vertex(float4 positionOS : POSITION) : SV_POSITION
+            {
+                return (0).xxxx;
+            }
+
+            // Minimal fragment function
+            half4 Fragment() : SV_Target
+            {
+                return half4(1, 1, 1, 1); // White color
+            }
+            #endif
+            ENDHLSL
+        }
+    }
+
+    // Fallback to Standard shader for Built-in Render Pipeline
+    FallBack "Standard"
+    CustomEditor "VRSL.Shaders.VRSLStandardInspector"
+}

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Standard.shader.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Standard.shader.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a088df73d2bf4e65a70b455b0cd7d95f
+timeCreated: 1747358215

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Unlit.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Unlit.shader
@@ -1,0 +1,126 @@
+Shader "VRSL/Other/Unlit"
+{
+    Properties
+    {
+        _MainTex ("Base (RGB)", 2D) = "white" {}
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType"="Opaque"
+            "RenderingPipeline"="UniversalPipeline"
+        }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            #pragma multi_compile_fog
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_FOG_COORDS(1)
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                UNITY_TRANSFER_FOG(o, o.vertex);
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                fixed4 col = tex2D(_MainTex, i.texcoord);
+                return col;
+            }
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType"="Opaque"
+        }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            #pragma multi_compile_fog
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                UNITY_FOG_COORDS(1)
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                UNITY_TRANSFER_FOG(o, o.vertex);
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                fixed4 col = tex2D(_MainTex, i.texcoord);
+                UNITY_APPLY_FOG(i.fogCoord, col);
+                    UNITY_OPAQUE_ALPHA(col.a);
+                return col;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Unlit.shader.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Unlit.shader.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 45aad9e069994b50955a2b176f4dd0ae
+timeCreated: 1747456318

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-DMXFunctions-URP.hlsl
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-DMXFunctions-URP.hlsl
@@ -1,0 +1,339 @@
+#ifndef VRSL_DMX_FUNCTIONS
+#define VRSL_DMX_FUNCTIONS
+
+#if defined(UNIVERSAL_RENDER_PIPELINE)
+
+#ifndef VRSL_DMX
+#define VRSL_DMX
+#endif
+#include "VRSL-Defines-URP.hlsl"
+
+#define IF(a, b, c) lerp(b, c, step((float) (a), 0.0))
+
+uint getDMXChannel()
+{
+    return (uint) round(UNITY_ACCESS_INSTANCED_PROP(Props, _DMXChannel));  
+}
+
+uint getNineUniverseMode()
+{
+    return (uint) UNITY_ACCESS_INSTANCED_PROP(Props, _NineUniverseMode);
+}
+
+#ifndef LASER
+uint checkPanInvertY()
+{
+    return (uint) UNITY_ACCESS_INSTANCED_PROP(Props, _PanInvert);
+}
+uint checkTiltInvertZ()
+{
+    return (uint) UNITY_ACCESS_INSTANCED_PROP(Props, _TiltInvert);
+}
+#endif
+
+float2 LegacyRead(int channel, int sector)
+{
+    // say we were on sector 6
+    // we need to move over 2 sectors
+    // and we need to move up 3 sectors
+
+    //1 sector is every 13 channels
+        float x = 0.02000;
+        float y = 0.02000;
+        //TRAVERSING THE Y AXIS OF THE DMX GRID
+        float ymod = floor(sector / 2.0);       
+
+        //TRAVERSING THE X AXIS OF THE DMX GRID
+        float xmod = sector % 2.0;
+
+        x+= (xmod * 0.50);
+        y+= (ymod * 0.04);
+        y-= sector >= 23 ? 0.025 : 0.0;
+        x+= (channel * 0.04);
+        x-= sector >= 40 ? 0.01 : 0.0;
+        //we are now on the correct
+        return float2(x,y);
+}
+
+float2 IndustryRead(int x, int y)
+{
+    float resMultiplierX = (_Udon_DMXGridRenderTexture_TexelSize.z / 13);
+    float2 xyUV = float2(0.0,0.0);
+    
+    xyUV.x = ((x * resMultiplierX) * _Udon_DMXGridRenderTexture_TexelSize.x);
+    xyUV.y = (y * resMultiplierX) * _Udon_DMXGridRenderTexture_TexelSize.y;
+    xyUV.y -= 0.001915;
+    xyUV.x -= 0.015;
+    return xyUV;
+}
+
+int getTargetRGBValue(uint universe)
+{
+    universe -=1;
+    return floor((int)(universe / 3));
+    //returns 0 for red, 1 for green, 2, for blue
+}
+
+//function for getting the value on the DMX Grid in the bottom right corner configuration
+half getValueAtCoords(uint DMXChannel, TEXTURE2D_PARAM(tex, samplerTex))
+{
+    uint universe = ceil(((int) DMXChannel)/512.0);
+    int targetColor = getTargetRGBValue(universe);
+    
+    universe-=1;
+    DMXChannel = targetColor > 0 ? DMXChannel - (((universe - (universe % 3)) * 512)) - (targetColor * 24) : DMXChannel;
+
+    uint x = DMXChannel % 13; // starts at 1 ends at 13
+    x = x == 0.0 ? 13.0 : x;
+    half y = DMXChannel / 13.0; // starts at 1 // doubles as sector
+    y = frac(y)== 0.00000 ? y - 1 : y;
+    if(x == 13.0) //for the 13th channel of each sector... Go down a sector for these DMX Channel Ranges...
+    {
+        //I don't know why, but we need this for some reason otherwise the 13th channel gets shifted around improperly.
+        //I"m not sure how to express these exception ranges mathematically. Doing so would be much more cleaner though.
+        y = DMXChannel >= 90 && DMXChannel <= 101 ? y - 1 : y;
+        y = DMXChannel >= 160 && DMXChannel <= 205 ? y - 1 : y;
+        y = DMXChannel >= 326 && DMXChannel <= 404 ? y - 1 : y;
+        y = DMXChannel >= 676 && DMXChannel <= 819 ? y - 1 : y;
+        y = DMXChannel >= 1339 ? y - 1 : y;
+    }
+    
+    float2 xyUV = _EnableCompatibilityMode == 1 ? LegacyRead(x-1.0,y) : IndustryRead(x,(y + 1.0));
+        
+    float4 uvcoords = float4(xyUV.x, xyUV.y, 0, 0);
+    half4 c = SAMPLE_TEXTURE2D_LOD(tex, samplerTex, xyUV, 0);
+    half value = 0.0;
+    
+    if(getNineUniverseMode() && _EnableCompatibilityMode != 1)
+    {
+        value = c.r;
+        value = IF(targetColor > 0, c.g, value);
+        value = IF(targetColor > 1, c.b, value);
+    }
+    else
+    {
+        half3 cRGB = half3(c.r, c.g, c.b);
+        value = Luminance(cRGB);
+    }
+    return value;
+}
+
+half getValueAtCoordsRaw(uint DMXChannel, TEXTURE2D_PARAM(tex, samplerTex))
+{
+    uint universe = ceil(((int) DMXChannel)/512.0);
+    int targetColor = getTargetRGBValue(universe);
+
+    universe-=1;
+    DMXChannel = targetColor > 0 ? DMXChannel - (((universe - (universe % 3)) * 512)) - (targetColor * 24) : DMXChannel;
+
+    uint x = DMXChannel % 13; // starts at 1 ends at 13
+    x = x == 0.0 ? 13.0 : x;
+    half y = DMXChannel / 13.0; // starts at 1 // doubles as sector
+    y = frac(y)== 0.00000 ? y - 1 : y;
+    
+    float2 xyUV = _EnableCompatibilityMode == 1 ? LegacyRead(x-1.0,y) : IndustryRead(x,(y + 1.0));
+
+    float4 uvcoords = float4(xyUV.x, xyUV.y, 0,0);
+    float4 c = SAMPLE_TEXTURE2D_LOD(tex, samplerTex, xyUV, 0);
+    half value = c.r;
+    value = IF(targetColor > 0, c.g, value);
+    value = IF(targetColor > 1, c.b, value);
+    return value;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#if defined(VOLUMETRIC_YES) || defined(PROJECTION_YES) || defined(FIXTURE_EMIT) || defined(FIXTURE_SHADOWCAST) || defined(VRSL_SURFACE) || defined(VRSL_FLARE)
+    half getMinMaxPan()
+    {
+        return UNITY_ACCESS_INSTANCED_PROP(Props,_MaxMinPanAngle);
+    }
+    half getMinMaxTilt()
+    {
+        return UNITY_ACCESS_INSTANCED_PROP(Props,_MaxMinTiltAngle);
+    }
+#endif
+
+uint isDMX()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props,_EnableDMX);
+}
+#ifndef LASER
+uint isStrobe()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props,_EnableStrobe);
+}
+
+uint instancedGOBOSelection()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props,_ProjectionSelection);
+}
+
+half getOffsetX()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props,_FixtureRotationX);
+}
+
+half getOffsetY()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props,_FixtureBaseRotationY);
+}
+
+half getStrobeFreq()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props,_StrobeFreq);
+}
+#endif
+half4 getEmissionColor()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props,_Emission);
+}
+#ifndef LASER
+half getConeWidth()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props,_ConeWidth) - 1.0;
+}
+
+uint isGOBOSpin()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props,_EnableSpin);
+}
+
+half getConeLength()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _ConeLength);
+}
+half getMaxConeLength(uint DMXChannel)
+{
+    #ifdef VOLUMETRIC_YES
+    half mcl = UNITY_ACCESS_INSTANCED_PROP(Props, _MaxConeLength);
+    return isDMX() == 1 && _EnableExtraChannels == 1 ? mcl + (getValueAtCoords(DMXChannel+1, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture)) * 4) : mcl;
+    #else
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _MaxConeLength);
+    #endif
+}
+#endif
+half getGlobalIntensity()
+{
+    return lerp(1.0,UNITY_ACCESS_INSTANCED_PROP(Props, _GlobalIntensity), UNITY_ACCESS_INSTANCED_PROP(Props, _GlobalIntensityBlend));
+}
+
+half getFinalIntensity()
+{
+    return UNITY_ACCESS_INSTANCED_PROP(Props, _FinalIntensity);
+}
+#ifndef LASER
+half GetStrobeOutput(uint DMXChannel)
+{
+    half strobe = getValueAtCoords(DMXChannel + 6, TEXTURE2D_ARGS(_Udon_DMXGridStrobeOutput, sampler_Udon_DMXGridStrobeOutput));
+
+    //check if we should even be strobing at all.
+    strobe = IF(isDMX() == 1, strobe, 1);
+    strobe = IF(isStrobe() == 1, strobe, 1);
+    
+    return strobe;
+}
+
+half GetStrobeOutputFiveCH(uint DMXChannel)
+{
+    half strobe = getValueAtCoords(DMXChannel + 4, TEXTURE2D_ARGS(_Udon_DMXGridStrobeOutput, sampler_Udon_DMXGridStrobeOutput));
+
+    //check if we should even be strobing at all.
+    strobe = IF(isDMX() == 1, strobe, 1);
+    strobe = IF(isStrobe() == 1, strobe, 1);
+    
+    return strobe;
+}
+
+half getDMXGoboSelection(uint DMXChannel)
+{
+    half goboSelect = 30.0;
+
+    #if defined(PROJECTION_MOVER) || defined (VOLUMETRIC_YES) 
+        goboSelect = IF(UNITY_ACCESS_INSTANCED_PROP(Props, _LegacyGoboRange) > 0, 42.5, goboSelect);
+    #endif
+
+    uint value = round(((getValueAtCoords(DMXChannel + 11, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture)))*255)/goboSelect);
+    value = isDMX() > 0.0 ? value : instancedGOBOSelection();
+    return clamp(value, 1, 8) -0.1;
+}
+
+half getGoboSpinSpeed (uint DMXChannel)
+{
+    #if defined(PROJECTION_YES) || defined(VOLUMETRIC_YES)
+        half status = getValueAtCoords(DMXChannel + 10, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+        half phase = getValueAtCoordsRaw(DMXChannel + 10, TEXTURE2D_ARGS(_Udon_DMXGridSpinTimer, sampler_Udon_DMXGridSpinTimer));
+        phase = checkPanInvertY() == 1 ? -phase : phase;
+        return status > 0.5 ? -phase * 4 : phase * 4;
+    #endif
+    return 0.0;
+}
+
+//function for getting the Intensity Value (Channel 6)
+half GetDMXIntensity(uint DMXChannel, half multiplier)
+{
+    return getValueAtCoords(DMXChannel + 5, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture)) * multiplier;
+}
+
+half GetDMXChannel(uint DMXChannel)
+{
+    return getValueAtCoords(DMXChannel, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+}
+
+//function for getting the Pan Value (Channel 2)
+half GetFinePanValue(uint DMXChannel)
+{
+    return getValueAtCoords(DMXChannel+1, TEXTURE2D_ARGS(_Udon_DMXGridRenderTextureMovement, sampler_Udon_DMXGridRenderTextureMovement));
+}
+half GetPanValue(uint DMXChannel)
+{
+    half inputValue = getValueAtCoords(DMXChannel, TEXTURE2D_ARGS(_Udon_DMXGridRenderTextureMovement, sampler_Udon_DMXGridRenderTextureMovement));
+    #if defined(VOLUMETRIC_YES) || defined(PROJECTION_YES) || defined(FIXTURE_EMIT) || defined(FIXTURE_SHADOWCAST) || defined(VRSL_SURFACE) || defined(VRSL_FLARE)
+        return IF(isDMX() == 1, ((getMinMaxPan() * 2) * (inputValue)) - getMinMaxPan(), 0.0);
+    #else
+        return IF(isDMX() == 1, ((_MaxMinPanAngle * 2) * (inputValue)) - _MaxMinPanAngle, 0.0);
+    #endif
+}
+
+half GetFineTiltValue(uint DMXChannel)
+{
+    return getValueAtCoords(DMXChannel+3, TEXTURE2D_ARGS(_Udon_DMXGridRenderTextureMovement, sampler_Udon_DMXGridRenderTextureMovement));
+}
+
+//function for getting the Tilt Value (Channel 3)
+half GetTiltValue(uint DMXChannel)
+{
+    half inputValue = getValueAtCoords(DMXChannel + 2, TEXTURE2D_ARGS(_Udon_DMXGridRenderTextureMovement, sampler_Udon_DMXGridRenderTextureMovement));
+    #if defined(VOLUMETRIC_YES) || defined(PROJECTION_YES) || defined(FIXTURE_EMIT) || defined(FIXTURE_SHADOWCAST) || defined(VRSL_SURFACE) || defined(VRSL_FLARE)
+        return IF(isDMX() == 1, ((getMinMaxTilt() * 2) * (inputValue)) - getMinMaxTilt(), 0.0);
+    #else
+        return IF(isDMX() == 1, ((_MaxMinTiltAngle * 2) * (inputValue)) - _MaxMinTiltAngle, 0.0);
+    #endif
+}
+
+//Function for getting the RGB Color Value (Channels 4, 5, and 6)
+half4 GetDMXColor(uint DMXChannel)
+{
+    half redchannel = getValueAtCoords(DMXChannel + 7, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+    half greenchannel = getValueAtCoords(DMXChannel + 8, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+    half bluechannel = getValueAtCoords(DMXChannel + 9, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+
+    #if defined(PROJECTION_YES)
+        redchannel = redchannel * _RedMultiplier;
+        bluechannel = bluechannel * _BlueMultiplier;
+        greenchannel = greenchannel * _GreenMultiplier;
+    #endif
+
+    return lerp(float4(0,0,0,1), half4(redchannel,greenchannel,bluechannel,1), GetDMXIntensity(DMXChannel, _FixtureMaxIntensity));
+}
+
+half getDMXConeWidth(uint DMXChannel) //Motor Speed Channel// CHANNEL 5
+{
+    half inputvalue = getValueAtCoords(DMXChannel + 4, TEXTURE2D_ARGS(_Udon_DMXGridRenderTexture, sampler_Udon_DMXGridRenderTexture));
+    half DMXWidth = lerp(0, 5.5, inputvalue) - 1.5;
+    return IF(isDMX() == 1, DMXWidth, getConeWidth());
+}
+#endif
+
+#endif
+#endif

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-DMXFunctions-URP.hlsl.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-DMXFunctions-URP.hlsl.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 997842c4a1154671af7cf467b6e8c334
+timeCreated: 1746557310

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines-URP.hlsl
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines-URP.hlsl
@@ -1,0 +1,226 @@
+﻿#ifndef VRSL_DEFINES
+#define VRSL_DEFINES
+
+#if defined(UNIVERSAL_RENDER_PIPELINE)
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+//MOVER LIGHT SYSTEM DEFINES
+TEXTURE2D(_MainTex);
+SAMPLER(sampler_MainTex);
+float4 _MainTex_ST;
+
+half _BlindingAngleMod;
+
+#ifdef VRSL_DMX
+    uint _UseRawGrid, _EnableExtraChannels;
+    uniform half4 _Udon_DMXGridRenderTexture_TexelSize;
+    TEXTURE2D(_Udon_DMXGridRenderTexture);
+    SAMPLER(sampler_Udon_DMXGridRenderTexture);
+    TEXTURE2D(_Udon_DMXGridRenderTextureMovement);
+    SAMPLER(sampler_Udon_DMXGridRenderTextureMovement);
+    TEXTURE2D(_Udon_DMXGridStrobeOutput);
+    SAMPLER(sampler_Udon_DMXGridStrobeOutput);
+    TEXTURE2D(_Udon_DMXGridSpinTimer);
+    SAMPLER(sampler_Udon_DMXGridSpinTimer);
+    half _SpinSpeed;
+
+#ifdef FIXTURE_EMIT
+            TEXTURE2D(_Udon_VRSL_GI_LightTexture);
+            uniform half4 _Udon_VRSL_GI_LightTexture_TexelSize;
+            SAMPLER(VRSL_PointClampSampler);
+            int _Udon_VRSL_GI_LightCount;
+            half _VRSLSpecularStrength;
+            half _VRSLGlossiness;
+#endif
+#endif
+
+#ifdef VRSL_AUDIOLINK
+    uniform half4 _AudioSpectrum_TexelSize; 
+    TEXTURE2D(_AudioSpectrum);
+    SAMPLER(sampler_AudioSpectrum);
+    TEXTURE2D(_SamplingTexture);
+    SAMPLER(sampler_SamplingTexture);
+#endif
+
+int _IsEven;
+#if !defined(VOLUMETRIC_YES) && !defined(PROJECTION_YES)
+TEXTURE2D(_MetallicGlossMap);
+SAMPLER(sampler_MetallicGlossMap);
+TEXTURE2D(_InsideConeNormalMap);
+SAMPLER(sampler_InsideConeNormalMap);
+TEXTURE2D(_SceneAlbedo);
+SAMPLER(sampler_SceneAlbedo);
+#endif
+
+#if defined(VRSL_SURFACE)
+    TEXTURE2D(_EmissionMask);
+    SAMPLER(sampler_EmissionMask);
+    TEXTURE2D(_NormalMap);
+    SAMPLER(sampler_NormalMap);
+    TEXTURE2D(_MetallicSmoothness);
+    SAMPLER(sampler_MetallicSmoothness);
+    float4 _EmissionMask_ST, _NormalMap_ST, _MetallicSmoothness_ST;
+#endif
+
+#ifdef FIXTURE_EMIT
+    TEXTURE2D(_DecorativeEmissiveMap);
+    SAMPLER(sampler_DecorativeEmissiveMap);
+    half _DecorativeEmissiveMapStrength;
+    float4 _DecorativeEmissiveMap_ST;
+#endif
+
+half4 _Color;
+half _Metallic;
+half _Glossiness;
+half _BumpScale;
+half _XOffset, _YOffset, _Fade, _FeatherOffset;
+uint _PureEmissiveToggle;
+half _RealtimeGIStrength;
+
+half _StripeSplit, _StripeSplit2, _StripeSplit3, _StripeSplit4, _StripeSplit5, _StripeSplit6, _StripeSplit7;
+half _StripeSplitScroll;
+half _StripeSplitStrength, _StripeSplitStrength2, _StripeSplitStrength3, _StripeSplitStrength4, _StripeSplitStrength5,
+     _StripeSplitStrength6, _StripeSplitStrength7;
+half4 _FixtureLensOrigin;
+
+float4x4 _viewToWorld;
+half _MinimumBeamRadius;
+
+#if defined(VOLUMETRIC_YES)
+#ifdef _HQ_MODE
+            TEXTURE2D(_NoiseTexHigh);
+            SAMPLER(sampler_NoiseTexHigh);
+#else
+            TEXTURE2D(_NoiseTex);
+            SAMPLER(sampler_NoiseTex);
+#endif
+
+    half _Noise2StretchInside;
+    half _Noise2Stretch;
+    half _Noise2X;
+    half _Noise2Y;
+    half _Noise2Z;
+    half _Noise2Power;
+
+    half _Noise2StretchInsideDefault;
+    half _Noise2StretchDefault;
+    half _Noise2XDefault;
+    half _Noise2YDefault;
+    half _Noise2ZDefault;
+    half _Noise2PowerDefault;
+
+    half _Noise2StretchInsidePotato;
+    half _Noise2StretchPotato;
+    half _Noise2XPotato;
+    half _Noise2YPotato;
+    half _Noise2ZPotato;
+    half _Noise2PowerPotato;
+#endif
+
+#ifdef _HQ_MODE
+    half4 _NoiseTexHigh_ST;
+#else
+half4 _NoiseTex_ST;
+#endif
+
+half _NoisePower, _NoiseSeed;
+uint _ToggleMagicNoise;
+
+half _SpecularLMOcclusion;
+half _SpecLMOcclusionAdjust;
+half _TriplanarFalloff;
+half _LMStrength;
+half _RTLMStrength;
+int _TextureSampleMode;
+int _LightProbeMethod;
+half _Saturation, _SaturationLength, _LensMaxBrightness, _UniversalIntensity;
+uint _EnableCompatibilityMode, _EnableVerticalMode;
+uint _GoboBeamSplitEnable;
+
+uniform const half compatSampleYAxis = 0.019231;
+uniform const half standardSampleYAxis = 0.00762;
+half4 _FixtureRotationOrigin;
+half _FixtureMaxIntensity;
+half _ProjectionIntensity;
+half _ProjectionRange;
+half4 _ProjectionRangeOrigin;
+half _ProjectionFade, _ProjectionFadeCurve, _ProjectionDistanceFallOff;
+half _AlphaProjectionIntensity;
+
+TEXTURE2D_X_FLOAT(_CameraDepthTexture);
+SAMPLER(sampler_CameraDepthTexture);
+uniform half4 _CameraDepthTexture_TexelSize;
+
+TEXTURE2D(_LightMainTex);
+SAMPLER(sampler_LightMainTex);
+float4 _LightMainTex_ST;
+
+TEXTURE2D(_ProjectionMainTex);
+SAMPLER(sampler_ProjectionMainTex);
+float4 _ProjectionMainTex_ST;
+
+half _ProjectionUVMod, _UseWorldNorm, _ProjectionRotation, _ProjectionUVMod2, _ProjectionUVMod3, _ProjectionUVMod4,
+     _ProjectionUVMod5, _ProjectionUVMod6, _ProjectionUVMod7, _ProjectionUVMod8;
+half _ModX;
+half _ModY;
+half _ConeSync, _ProjectionShadowHarshness, _BlindingStrength;
+
+half _PulseSpeed, _BlendSrc, _BlendDst, _BlendOp;
+half _FadeStrength, _FadeAmt, _DistFade, _ProjectionMaxIntensity, _IntensityCutoff;
+half _InnerFadeStrength, _InnerIntensityCurve, _FixutreIntensityMultiplier;
+half _RedMultiplier, _GreenMultiplier, _BlueMultiplier;
+
+int _EnableStaticEmissionColor;
+half4 _StaticEmission;
+half _ProjectionCutoff, _ProjectionOriginCutoff, _GradientMod, _GradientModGOBO;
+half _ClippingThreshold, _RenderTextureMultiplier;
+
+// Instanced Properties
+UNITY_INSTANCING_BUFFER_START(Props)
+    #ifdef VRSL_DMX
+        UNITY_DEFINE_INSTANCED_PROP(uint, _DMXChannel)
+        UNITY_DEFINE_INSTANCED_PROP(uint, _NineUniverseMode)
+        UNITY_DEFINE_INSTANCED_PROP(uint, _EnableDMX)
+        UNITY_DEFINE_INSTANCED_PROP(uint, _LegacyGoboRange)
+    #endif
+    #ifdef VRSL_AUDIOLINK
+        UNITY_DEFINE_INSTANCED_PROP(half, _EnableAudioLink)
+        UNITY_DEFINE_INSTANCED_PROP(half, _EnableColorChord)
+        UNITY_DEFINE_INSTANCED_PROP(half, _NumBands)
+        UNITY_DEFINE_INSTANCED_PROP(half, _Band)
+        UNITY_DEFINE_INSTANCED_PROP(half, _BandMultiplier)
+        UNITY_DEFINE_INSTANCED_PROP(half, _Delay)
+        UNITY_DEFINE_INSTANCED_PROP(uint, _EnableColorTextureSample)
+        UNITY_DEFINE_INSTANCED_PROP(half, _TextureColorSampleX)
+        UNITY_DEFINE_INSTANCED_PROP(half, _TextureColorSampleY)
+        UNITY_DEFINE_INSTANCED_PROP(half, _SpinSpeed)
+        UNITY_DEFINE_INSTANCED_PROP(half, _ThemeColorTarget)
+        UNITY_DEFINE_INSTANCED_PROP(uint, _EnableThemeColorSampling)
+        UNITY_DEFINE_INSTANCED_PROP(uint, _UseTraditionalSampling)
+    #endif
+    #ifdef VRSL_SURFACE
+        UNITY_DEFINE_INSTANCED_PROP(half, _CurveMod)
+    #endif
+    UNITY_DEFINE_INSTANCED_PROP(uint, _PanInvert)
+    UNITY_DEFINE_INSTANCED_PROP(uint, _TiltInvert)
+    UNITY_DEFINE_INSTANCED_PROP(uint, _EnableStrobe)
+    UNITY_DEFINE_INSTANCED_PROP(uint, _EnableSpin)
+    UNITY_DEFINE_INSTANCED_PROP(half, _StrobeFreq)
+    UNITY_DEFINE_INSTANCED_PROP(half, _FixtureRotationX)
+    UNITY_DEFINE_INSTANCED_PROP(half, _FixtureBaseRotationY)
+    UNITY_DEFINE_INSTANCED_PROP(uint, _ProjectionSelection)
+    UNITY_DEFINE_INSTANCED_PROP(half4, _Emission)
+    UNITY_DEFINE_INSTANCED_PROP(half, _ConeWidth)
+    UNITY_DEFINE_INSTANCED_PROP(half, _ConeLength)
+    UNITY_DEFINE_INSTANCED_PROP(half, _GlobalIntensity)
+    UNITY_DEFINE_INSTANCED_PROP(half, _GlobalIntensityBlend)
+    UNITY_DEFINE_INSTANCED_PROP(half, _FinalIntensity)
+    UNITY_DEFINE_INSTANCED_PROP(half, _MaxConeLength)
+    UNITY_DEFINE_INSTANCED_PROP(half, _MaxMinPanAngle)
+    UNITY_DEFINE_INSTANCED_PROP(half, _MaxMinTiltAngle)
+UNITY_INSTANCING_BUFFER_END(Props)
+
+#endif
+
+#endif

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines-URP.hlsl.meta
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines-URP.hlsl.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 47b472e5d3f744a7888f64470e2ccfa0
+timeCreated: 1746553710

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-LensFlare.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-LensFlare.shader
@@ -63,6 +63,355 @@
     }
     SubShader
     {
+        Tags
+        {
+            "RenderType"="Transparent" "Queue" = "Transparent+200" "RenderingPipeline" = "UniversalPipeline"
+        }
+        LOD 100
+
+        Pass
+        {
+            AlphaToMask [_AlphaToCoverage]
+            Zwrite Off
+            ZTest Off
+            Blend One [_BlendDst]
+            Cull Back
+            Lighting Off
+            Tags
+            {
+                "LightMode" = "UniversalForward"
+            }
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+                Pass Keep
+            }
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma multi_compile_local _ _USE_DEPTH_LIGHT
+            #pragma shader_feature _1CH_MODE _4CH_MODE _5CH_MODE _13CH_MODE
+            #define VRSL_DMX
+            #define VRSL_FLARE
+            // make fog work
+            // #pragma multi_compile_fog
+            #pragma multi_compile_instancing
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                half4 color : COLOR;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                // UNITY_FOG_COORDS(1)
+                float4 vertex : SV_POSITION;
+                float4 screenPos : TEXCOORD1;
+                float4 worldDirection : TEXCOORD2;
+                float4 vertexWorldPos : TEXCOORD3;
+                half4 color : TEXCOORD4;
+                float maskX : TEXCOORD5;
+                float4 dmx : TEXCOORD6;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                // will turn into this in non OpenGL / non PSSL -> uint instanceID : SV_InstanceID;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #define COUNT 8 //you can edit to any number(e.g. 1~32), the lower the faster. Keeping this number a const can enable many compiler optimizations
+
+
+            //sampler2D _CameraDepthTexture;
+            #include "Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Shared/VRSL-Defines.cginc"
+            // sampler2D _MainTex;
+            //            float4 _MainTex_ST;
+            //half4 _Emission;
+            half _ColorSat, _ScaleFactor, _ReferenceDistance, _UVScale;
+            float _LightSourceViewSpaceRadius;
+            float _DepthOcclusionTestZBias;
+
+            float _StartFadeinDistanceWorldUnit;
+            float _EndFadeinDistanceWorldUnit;
+
+            float _UsePreMultiplyAlpha;
+
+            float _FlickerAnimSpeed;
+            float _FlickResultIntensityLowestPoint;
+            float _ShouldDoFlicker;
+            half _RemoveTextureArtifact, _CurveMod;
+            uint _UseDepthLight;
+            #include "../Shared/VRSL-DMXFunctions.cginc"
+
+            float4x4 GetWorldToViewMatrix()
+            {
+                return UNITY_MATRIX_V;
+            }
+
+            float4x4 GetObjectToWorldMatrix()
+            {
+                return UNITY_MATRIX_M;
+            }
+
+            float3 TransformWorldToView(float3 positionWS)
+            {
+                return mul(GetWorldToViewMatrix(), float4(positionWS, 1.0)).xyz;
+            }
+
+            float3 TransformObjectToWorld(float3 vertex)
+            {
+                return mul(GetObjectToWorldMatrix(), float4(vertex, 1.0)).xyz;
+            }
+
+            inline float4 CalculateFrustumCorrection()
+            {
+                float x1 = -UNITY_MATRIX_P._31 / (UNITY_MATRIX_P._11 * UNITY_MATRIX_P._34);
+                float x2 = -UNITY_MATRIX_P._32 / (UNITY_MATRIX_P._22 * UNITY_MATRIX_P._34);
+                return float4(
+                    x1, x2, 0,
+                    UNITY_MATRIX_P._33 / UNITY_MATRIX_P._34 + x1 * UNITY_MATRIX_P._13 + x2 * UNITY_MATRIX_P._23);
+            }
+
+            //CREDIT TO DJ LUKIS FOR MIRROR DEPTH CORRECTION
+            inline float CorrectedLinearEyeDepth(float z, float B)
+            {
+                return 1.0 / (z / UNITY_MATRIX_P._34 + B);
+            }
+
+            float3 RGB2HSV(float3 c)
+            {
+                float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
+                float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+
+                float d = q.x - min(q.w, q.y);
+                float e = 1.0e-10;
+                return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+            }
+
+            //#include "../Basic Surface Shaders/VRSL-StandardSurface-Functions.cginc"
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v); //Insert
+                    UNITY_INITIALIZE_OUTPUT(v2f, o); //Insert
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o); //Insert
+
+                uint dmx = getDMXChannel();
+                float intensity = 0.0f;
+                #if _1CH_MODE
+                half4 e = IF(isDMX() == 1, getValueAtCoords(dmx+1, _Udon_DMXGridRenderTexture) * getEmissionColor(),
+                    getEmissionColor());
+                intensity = GetDMXChannel(dmx);
+                #elif _4CH_MODE
+                    float4 DMXcol = getEmissionColor();
+                    DMXcol *= float4(getValueAtCoords(dmx+1, _Udon_DMXGridRenderTexture), getValueAtCoords(dmx+2, _Udon_DMXGridRenderTexture), getValueAtCoords(dmx+3, _Udon_DMXGridRenderTexture), 1);
+                    float4 coll = IF(isDMX() == 1, DMXcol, getEmissionColor());
+                    half4 e = coll;
+                    intensity = GetDMXChannel(dmx);
+                #elif _5CH_MODE
+                    float strobe = IF(isStrobe() == 1, GetStrobeOutputFiveCH(dmx), 1);
+                    float4 DMXcol = getEmissionColor();
+                    DMXcol *= float4(getValueAtCoords(dmx+1, _Udon_DMXGridRenderTexture), getValueAtCoords(dmx+2, _Udon_DMXGridRenderTexture), getValueAtCoords(dmx+3, _Udon_DMXGridRenderTexture), 1);
+                    float4 coll = IF(isDMX() == 1, DMXcol, getEmissionColor());
+                    half4 e = coll * strobe;
+                    intensity = GetDMXChannel(dmx);
+                #elif _13CH_MODE
+                    float strobe = IF(isStrobe() == 1, GetStrobeOutput(dmx), 1);
+                    float4 DMXcol = getEmissionColor();
+                    DMXcol *= GetDMXColor(dmx);
+                    float4 coll = IF(isDMX() == 1, DMXcol, getEmissionColor());
+                    half4 e = coll * strobe;
+                    intensity = GetDMXIntensity(dmx, 1.0);
+                #endif
+
+                e = IF(isDMX() == 1, lerp(half4(-_CurveMod,-_CurveMod,-_CurveMod,1), e, pow(intensity, 1.0)), e);
+                e = clamp(e, half4(0, 0, 0, 1),
+                    half4(_FixtureMaxIntensity * 2, _FixtureMaxIntensity * 2, _FixtureMaxIntensity * 2, 1));
+
+                #ifdef _ALPHATEST_ON
+                    e*= (_FixutreIntensityMultiplier*0.25);
+                #else
+                e *= _FixutreIntensityMultiplier;
+                #endif
+                e = float4(((e.rgb * _FixtureMaxIntensity) * getGlobalIntensity()) * getFinalIntensity(), e.w);
+                e *= _UniversalIntensity;
+                o.dmx = e;
+                float3 eHSV = RGB2HSV(e.rgb);
+                if (eHSV.z <= 0.01)
+                {
+                    v.vertex = float4(0, 0, 0, 0);
+                    o.vertex = UnityObjectToClipPos(v.vertex);
+                    return o;
+                }
+
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                o.color = v.color * e;
+
+                float3 quadPivotPosOS = float3(0, 0, 0);
+                float3 quadPivotPosWS = TransformObjectToWorld(quadPivotPosOS);
+                float3 quadPivotPosVS = TransformWorldToView(quadPivotPosWS);
+
+                //get transform.lossyScale using:
+                //https://forum.unity.com/threads/can-i-get-the-scale-in-the-transform-of-the-object-i-attach-a-shader-to-if-so-how.418345/
+                float2 scaleXY_WS = float2(
+                    length(float3(GetObjectToWorldMatrix()[0].x, GetObjectToWorldMatrix()[1].x,
+    GetObjectToWorldMatrix()[2].x)), // scale x axis
+                    length(float3(GetObjectToWorldMatrix()[0].y, GetObjectToWorldMatrix()[1].y,
+         GetObjectToWorldMatrix()[2].y)) // scale y axis
+                );
+
+                float3 posVS = quadPivotPosVS + float3(v.vertex.xy * scaleXY_WS, 0);
+                //recontruct quad 4 points in view space
+
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //complete SV_POSITION's view space to HClip space transformation
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                o.vertex = mul(UNITY_MATRIX_P, float4(posVS, 1));
+
+
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //do smooth visibility test using brute force forloop (COUNT*2+1)^2 times inside a view space 2D grid area
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                float visibilityTestPassedCount = 0;
+                float linearEyeDepthOfFlarePivot = -quadPivotPosVS.z;
+                //view space's forward is pointing to -Z, but we want +Z, so negate it
+                float testLoopSingleAxisWidth = COUNT * 2 + 1;
+                float totalTestCount = testLoopSingleAxisWidth * testLoopSingleAxisWidth;
+                float divider = 1.0 / totalTestCount;
+                float maxSingleAxisOffset = _LightSourceViewSpaceRadius / testLoopSingleAxisWidth;
+
+                //Test for n*n grid in view space, where quad pivot is grid's center.
+                //For each iteration,
+                //if that test point passed the scene depth occlusion test, we add 1 to visibilityTestPassedCount
+                #if _USE_DEPTH_LIGHT
+                
+                    for(int x = -COUNT; x <= COUNT; x++)
+                    {
+                        for(int y = -COUNT; y <= COUNT ; y++)
+                        {
+                            float3 testPosVS = quadPivotPosVS;
+                            testPosVS.xy += float2(x,y) * maxSingleAxisOffset;//add 2D test grid offset, in const view space unit
+                            float4 PivotPosCS = mul(UNITY_MATRIX_P,float4(testPosVS,1));
+                            float4 PivotScreenPos = ComputeScreenPos(PivotPosCS);
+                            float2 screenUV = PivotScreenPos.xy/PivotScreenPos.w;
+
+                            //if screenUV out of bound, treat it as occluded, because no correct depth texture data can be used to compare
+                            if(screenUV.x > 1 || screenUV.x < 0 || screenUV.y > 1 || screenUV.y < 0)
+                                continue; //exit means occluded
+
+                            //we don't have tex2D() in vertex shader, because rasterization is not done by GPU, so we use tex2Dlod() with mip0 instead
+                            float4 ssd = SAMPLE_DEPTH_TEXTURE_LOD(_CameraDepthTexture, float4(screenUV, 0.0, 0.0));//(uv.x,uv.y,0,mipLevel)
+                            float sampledSceneDepth = ssd.x;
+                            float linearEyeDepthFromSceneDepthTexture = LinearEyeDepth(sampledSceneDepth);
+                            float linearEyeDepthFromSelfALU = PivotPosCS.w; //clip space .w is view space z, = linear eye depth
+
+                            //do the actual depth comparision test
+                            //+1 means flare test point is visible in screen space
+                            //+0 means flare test point blocked by other objects in screen space, not visible
+                            visibilityTestPassedCount += linearEyeDepthFromSelfALU + _DepthOcclusionTestZBias < linearEyeDepthFromSceneDepthTexture ? 1 : 0; 
+                        }
+                    }
+                    float visibilityResult01 = visibilityTestPassedCount * divider;//0~100% visiblility result 
+
+                    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                    //if camera too close to flare , smooth fade out to prevent flare blocking camera too much (usually for fps games)
+                    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                    visibilityResult01 *= smoothstep(_StartFadeinDistanceWorldUnit,_EndFadeinDistanceWorldUnit,linearEyeDepthOfFlarePivot);
+                    o.vertex = visibilityResult01 < divider ? 0 : o.vertex;
+                    o.color.a *= visibilityResult01;
+                #endif
+                // if(_ShouldDoFlicker)
+                // {
+                //     float flickerMul = 0;
+                //     //TODO: expose more control to noise? (send me an issue in GitHub, if anyone need this)
+                //     flickerMul += saturate(sin(_Time.y * _FlickerAnimSpeed * 1.0000)) * (1-_FlickResultIntensityLowestPoint) + _FlickResultIntensityLowestPoint;
+                //     flickerMul += saturate(sin(_Time.y * _FlickerAnimSpeed * 0.6437)) * (1-_FlickResultIntensityLowestPoint) + _FlickResultIntensityLowestPoint;   
+                //     visibilityResult01 *= saturate(flickerMul/2);
+                // }
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //apply all combinations(visibilityResult01) to vertex color
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //premultiply alpha to rgb after alpha's calculation is done
+                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// 
+                o.color.rgb *= o.color.a;
+                o.color.a = _UsePreMultiplyAlpha ? o.color.a : 0;
+
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //pure optimization:
+                //if flare is invisible or nearly invisible,
+                //invalid this vertex (and all connected vertices).
+                //This 100% early exit at clipping stage will prevent any rasterization & fragment shader cost at all
+                //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+                // float3 hsvFC = RGB2HSV(o.color.xyz);
+                // hsvFC.y = 0.0;
+                float4 e2 = float4(1, 1, 1, o.color.w);
+
+
+                o.maskX = lerp(1, 0, pow(distance(half2(0.5, 0.5), o.uv), _FadeAmt));
+                float satMask = lerp(1, 0, pow(distance(half2(0.5, 0.5), o.uv), _ColorSat));
+                o.color = lerp(o.color, e2, satMask);
+
+
+                #if _ALPHATEST_ON
+                    o.screenPos = ComputeScreenPos(o.vertex);
+                #endif
+                //  UNITY_TRANSFER_FOG(o,o.vertex);
+                return o;
+            }
+
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                #if _ALPHATEST_ON
+                    float2 pos = i.screenPos.xy / i.screenPos.w;
+                    pos *= _ScreenParams.xy;
+                    float DITHER_THRESHOLDS[16] =
+                    {
+                        1.0 / 17.0,  9.0 / 17.0,  3.0 / 17.0, 11.0 / 17.0,
+                        13.0 / 17.0,  5.0 / 17.0, 15.0 / 17.0,  7.0 / 17.0,
+                        4.0 / 17.0, 12.0 / 17.0,  2.0 / 17.0, 10.0 / 17.0,
+                        16.0 / 17.0,  8.0 / 17.0, 14.0 / 17.0,  6.0 / 17.0
+                    };
+                    int index = (int)((uint(pos.x) % 4) * 4 + uint(pos.y) % 4);
+                    float4 col = saturate(tex2D(_MainTex, i.uv ));
+                   // col *= i.maskX;
+                    //clip((col.a) - DITHER_THRESHOLDS[index]);
+                    clip((((col.r + col.g + col.b)/3) * (_ClippingThreshold * 10)) - DITHER_THRESHOLDS[index]);
+                    UNITY_APPLY_FOG(i.fogCoord, col);
+                    return col * i.dmx;
+                #else
+                fixed4 col = saturate(tex2D(_MainTex, i.uv) - _RemoveTextureArtifact) * i.color;
+                // apply fog
+                UNITY_APPLY_FOG(i.fogCoord, col);
+
+                col *= i.maskX;
+                return col;
+                #endif
+            }
+            ENDCG
+        }
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
+    SubShader
+    {
         Tags { "RenderType"="Transparent" "Queue" = "Transparent+200" }
         LOD 100
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-LensFlare.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-LensFlare.shader
@@ -312,6 +312,9 @@
                             //we don't have tex2D() in vertex shader, because rasterization is not done by GPU, so we use tex2Dlod() with mip0 instead
                             float4 ssd = SAMPLE_DEPTH_TEXTURE_LOD(_CameraDepthTexture, float4(screenUV, 0.0, 0.0));//(uv.x,uv.y,0,mipLevel)
                             float sampledSceneDepth = ssd.x;
+                            #if !UNITY_REVERSED_Z
+                            sampledSceneDepth = lerp(UNITY_NEAR_CLIP_VALUE, 1, sampledSceneDepth);
+                            #endif
                             float linearEyeDepthFromSceneDepthTexture = LinearEyeDepth(sampledSceneDepth);
                             float linearEyeDepthFromSelfALU = PivotPosCS.w; //clip space .w is view space z, = linear eye depth
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-ProjectionMesh.shader
@@ -82,6 +82,179 @@
 
 
 	}
+
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+        }
+        Pass
+        {
+            Tags
+            {
+                "ForceNoShadowCasting"="True" "IgnoreProjector"="True" "LightMode" = "UniversalForward"
+            }
+            AlphaToMask [_AlphaToCoverage]
+            Cull Front
+            Ztest GEqual
+            ZWrite Off
+            Blend DstColor [_BlendDst]
+            BlendOp Add
+            Lighting Off
+            //SeparateSpecular Off
+
+            Stencil
+            {
+                Ref 142
+                Comp NotEqual
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #pragma shader_feature_local _CHANNEL_MODE
+            #pragma shader_feature_local _MULTISAMPLEDEPTH
+            //#pragma multi_compile_fog
+            #pragma multi_compile_instancing
+
+            #define PROJECTION_YES
+            #define VRSL_DMX
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float3 texcoord : TEXCOORD1;
+                float4 color : COLOR;
+                float3 normal : TEXCOORD3;
+                float3 tangent : TANGENT;
+                float4 projectionorigin : TEXCOORD2;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float3 ray : TEXCOORD2;
+                float4 screenPos : TEXCOORD4;
+                float4 color : COLOR;
+                float3 normal : TEXCOORD3;
+                float2 dmx: TEXCOORD10;
+                float4 projectionorigin : TEXCOORD5;
+                float4 worldDirection : TEXCOORD6;
+                float4 worldPos : TEXCOORD7;
+                float2 intensityStrobe : TEXCOORD11;
+                float4 rgbColor : TEXCOORD12;
+                float4 emissionColor : TEXCOORD13;
+                float2 globalFinalIntensity : TEXCOORD14;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            #include "../Shared/VRSL-Defines.cginc"
+            #include "../Shared/VRSL-DMXFunctions.cginc"
+            #include "VRSL-StaticLight-ProjectionFrag.cginc"
+            //float _AlphaProjectionIntensity;
+
+            #define IF(a, b, c) lerp(b, c, step((fixed) (a), 0));
+
+            float4 CalculateProjectionScaleRange(appdata v, float4 input, float scalar)
+            {
+                float4 oldinput = input;
+                float4x4 scaleMatrix = float4x4(
+                    scalar, 0, 0, 0,
+                    0, scalar, 0, 0,
+                    0, 0, scalar, 0,
+                    0, 0, 0, 1.0
+                );
+                float4 newOrigin = input.w * _ProjectionRangeOrigin;
+                input.xyz = input.xyz - newOrigin;
+                //Do stretch
+                float4 newProjectionScale = mul(scaleMatrix, input);
+                input.xyz = newProjectionScale;
+                input.xyz = input.xyz + newOrigin;
+                input.xyz = IF(v.color.g != 0, input.xyz, oldinput);
+                return input;
+            }
+
+            inline float4 CalculateFrustumCorrection()
+            {
+                float x1 = -UNITY_MATRIX_P._31 / (UNITY_MATRIX_P._11 * UNITY_MATRIX_P._34);
+                float x2 = -UNITY_MATRIX_P._32 / (UNITY_MATRIX_P._22 * UNITY_MATRIX_P._34);
+                return float4(
+                    x1, x2, 0,
+                    UNITY_MATRIX_P._33 / UNITY_MATRIX_P._34 + x1 * UNITY_MATRIX_P._13 + x2 * UNITY_MATRIX_P._23);
+            }
+
+
+            //VERTEX SHADER
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                UNITY_TRANSFER_INSTANCE_ID(v, o);
+                uint dmx = getDMXChannel();
+                #ifdef _CHANNEL_MODE
+			        o.intensityStrobe = float2(getValueAtCoords(dmx, _Udon_DMXGridRenderTexture),GetStrobeOutputFiveCH(dmx));
+			        o.rgbColor = float4(getValueAtCoords(dmx+1, _Udon_DMXGridRenderTexture), getValueAtCoords(dmx+2, _Udon_DMXGridRenderTexture), getValueAtCoords(dmx+3, _Udon_DMXGridRenderTexture), 1);
+			        o.rgbColor *= o.intensityStrobe.x;
+			        o.emissionColor = getEmissionColor();
+                #else
+                    o.intensityStrobe = float2(GetDMXIntensity(dmx, 1.0), GetStrobeOutput(dmx));
+                    o.rgbColor = GetDMXColor(dmx);
+                    o.emissionColor = getEmissionColor();
+                #endif
+                o.globalFinalIntensity.x = getGlobalIntensity();
+                o.globalFinalIntensity.y = getFinalIntensity();
+
+                v.vertex = CalculateProjectionScaleRange(v, v.vertex, _ProjectionRange);
+                o.projectionorigin = CalculateProjectionScaleRange(v, _ProjectionRangeOrigin, _ProjectionRange);
+                //move verts to clip space
+                o.pos = UnityObjectToClipPos(v.vertex);
+
+                //get screen space position of verts
+                o.screenPos = ComputeScreenPos(o.pos);
+                //Putting in the vertex position before the transformation seems to somewhat move the projection correctly, but is still incorrect...?
+                o.ray = UnityObjectToViewPos(v.vertex).xyz;
+                //invert z axis so that it projects from camera properly
+                o.ray *= float3(1, 1, -1);
+                //saving vertex color incase needing to perform rotation calculation in fragment shader
+                o.color = v.color;
+                o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+                //For Mirror Depth Correction
+                o.worldDirection.xyz = o.worldPos.xyz - _WorldSpaceCameraPos;
+                // pack correction factor into direction w component to save space
+                o.worldDirection.w = dot(o.pos, CalculateFrustumCorrection());
+                if (((all(o.rgbColor <= float4(0.05, 0.05, 0.05, 1)) || o.intensityStrobe.x <= 0.05) && isDMX() == 1) ||
+                    o.globalFinalIntensity.x <= 0.005 || o.globalFinalIntensity.y <= 0.005 || all(
+                        o.emissionColor <= float4(0.005, 0.005, 0.005, 1.0)))
+                {
+                    v.vertex = float4(0, 0, 0, 0);
+                    o.pos = UnityObjectToClipPos(v.vertex);
+                }
+
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                //UNITY_SETUP_INSTANCE_ID(i);
+                return ProjectionFrag(i);
+            }
+            ENDCG
+        }
+
+        // Used for handling Depth Buffer (DBuffer) and Depth Priming
+        UsePass "Universal Render Pipeline/Lit/DepthOnly"
+        UsePass "Universal Render Pipeline/Lit/DepthNormals"
+    }
+
 		SubShader
 	{
 		//UNITY_REQUIRE_ADVANDED_BLEND(all_equations)


### PR DESCRIPTION
All changes here retain existing compatibility with BIRP. This PR just handles adding URP support where needed (including adding a custom shader that implements Standard/URPLit logic without compiler errors).

- Add URP compatible SubShader to all shaders (existing BIRP SubShaders are unmodified)
- Add cross-compatible (birp/urp) standard-lit shader and unlit shader with inspector.
- Add pipeline detector script for setting a shader keyword for URP or HDRP.
- Update usage of Standard and Unlit to the crosscompat standard-lit and unlit shaders.
- Add simplified DMX reader prefabs for straightforward extraction of DMX data from any texture.
- Update VRSL's audiolink controller prefab with new crosscompat materials.
  - (Not all shaders on the controller are URP compatible, but the remaining need updated from AudioLink's side)
- Incorporate corrections from #42 to the URP SubShader portions only (for easy merging with that PR).

Sample implementation in Unity 6 using URP: https://streamable.com/thgh85