### PR TITLE
Only Force Disable Depth and Volumetric inside VRChat

### DIFF
--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_LocalUIControlPanel.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_LocalUIControlPanel.cs
@@ -167,7 +167,7 @@ namespace VRSL
 
         public bool VolumetricNoise
         {
-#if UNITY_ANDROID
+#if (UNITY_ANDROID || UNITY_IOS) && UDONSHARP
             set {
                 _volumetricNoise = false;
                 _CheckDepthLightStatus();
@@ -188,7 +188,7 @@ namespace VRSL
 
         public bool RequireDepthLight
         {
-#if UNITY_ANDROID
+#if (UNITY_ANDROID || UNITY_IOS) && UDONSHARP
             set {
                 _requireDepthLight = false;
                 _CheckDepthLightStatus();


### PR DESCRIPTION
This commit is made in faith that a Developer building for Standard Unity tests the Application on the hardware it is intended for.
*(some optimization maybe required)*