### PR TITLE
Fix null check of globalStrobeToggleButton

### DIFF
--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_LocalUIControlPanel.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRSL_LocalUIControlPanel.cs
@@ -229,8 +229,11 @@ namespace VRSL
         void SetGlobalStrobeUI()
         {
             
-            if(globalStrobeToggleButton){globalStrobeToggleButton.colors = GlobalDisableStrobe ? cbOn : defaultColorBlock;}
-            globalStrobeToggleButton.gameObject.SetActive(isUsingDMX);
+            if(globalStrobeToggleButton){
+                globalStrobeToggleButton.colors = GlobalDisableStrobe ? cbOn : defaultColorBlock;
+                globalStrobeToggleButton.gameObject.SetActive(isUsingDMX);
+            }
+            
         }
 
         void SetStrobeTextureStatus()


### PR DESCRIPTION
the check was not covering the whole function so if you dont have the button it will crash on start.