### PR TITLE
Fix URP subshaders tag typo

### DIFF
--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Discoball/VRSL-AudioLink-Discoball.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/Discoball/VRSL-AudioLink-Discoball.shader
@@ -45,7 +45,7 @@
              "ForceNoShadowCasting"="True"
              "IgnoreProjector"="True"
              "RenderType" = "Transparent"
-             "RenderingPipeline" = "UniversalPipeline"
+             "RenderPipeline" = "UniversalPipeline"
          }
          Offset -1, -5
          Stencil

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-BasicLaser.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-BasicLaser.shader
@@ -52,7 +52,7 @@
     {
         Tags
         {
-            "RenderType"="Transparent" "Queue" = "Transparent+4" "RenderingPipeline" = "UniversalPipeline"
+            "RenderType"="Transparent" "Queue" = "Transparent+4" "RenderPipeline" = "UniversalPipeline"
         }
         Cull Off
         Blend One One

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-FixtureMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-FixtureMesh.shader
@@ -115,7 +115,7 @@
     {
         Tags
         {
-            "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline"
         }
 
         Pass

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-ProjectionMesh.shader
@@ -132,7 +132,7 @@ Shader "VRSL/AudioLink/Standard Mover/Projection"
     {
         Tags
         {
-            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderPipeline" = "UniversalPipeline"
         }
         Pass
         {

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-VolumetricMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-StandardMover-VolumetricMesh.shader
@@ -151,7 +151,7 @@
     {
         Tags
         {
-            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderPipeline" = "UniversalPipeline"
         }
         //Volumetric Pass
         Pass

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-FixtureMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-FixtureMesh.shader
@@ -114,7 +114,7 @@
     {
         Tags
         {
-            "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderingPipeline"="UniversalPipeline"
+            "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderPipeline"="UniversalPipeline"
         }
 
         Pass

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-ProjectionMesh.shader
@@ -127,7 +127,7 @@
     {
         Tags
         {
-            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderPipeline" = "UniversalPipeline"
         }
 
         Pass

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-VolumetricMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/MovingLights/VRSL-AudioLink-WashMover-VolumetricMesh.shader
@@ -151,7 +151,7 @@
     {
         Tags
         {
-            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderPipeline" = "UniversalPipeline"
         }
         //Volumetric Pass
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-FixtureMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-FixtureMesh.shader
@@ -55,7 +55,7 @@
     {
         Tags
         {
-            "RenderType" = "Opaque" "RenderingPipeline" = "UniversalPipeline"
+            "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline"
         }
         LOD 200
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-LensFlare.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-LensFlare.shader
@@ -69,7 +69,7 @@
     {
         Tags
         {
-            "RenderType"="Transparent" "Queue" = "Transparent+200" "RenderingPipeline" = "UniversalPipeline"
+            "RenderType"="Transparent" "Queue" = "Transparent+200" "RenderPipeline" = "UniversalPipeline"
         }
         LOD 100
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/AudioLink/StaticLights/VRSL-AudioLink-StaticLight-ProjectionMesh.shader
@@ -115,7 +115,7 @@
     {
         Tags
         {
-            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderPipeline" = "UniversalPipeline"
         }
         Pass
         {

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Discoball/VRSL-Discoball.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Discoball/VRSL-Discoball.shader
@@ -32,7 +32,7 @@
              "ForceNoShadowCasting"="True"
              "IgnoreProjector"="True"
              "RenderType" = "Transparent"
-             "RenderingPipeline"="UniversalPipeline"
+             "RenderPipeline"="UniversalPipeline"
          }
          Offset -1, -5
          Stencil

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-BasicLaser-DMX.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-BasicLaser-DMX.shader
@@ -39,7 +39,7 @@
     }
     SubShader
     {
-		Tags { "RenderType"="Transparent" "Queue" = "Transparent+1" "RenderingPipeline" = "UniversalPipeline" }
+		Tags { "RenderType"="Transparent" "Queue" = "Transparent+1" "RenderPipeline" = "UniversalPipeline" }
 		Cull Off
 		Blend One One
 		Zwrite Off

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-FixtureMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-FixtureMesh.shader
@@ -57,7 +57,7 @@
 	// URP subshader must be first
 	SubShader
 	{
-		Tags { "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderingPipeline" = "UniversalPipeline" }
+		Tags { "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline" }
 
 		Pass
 	    {

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-ProjectionMesh.shader
@@ -151,7 +151,7 @@
     {
         Tags
         {
-            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderPipeline" = "UniversalPipeline"
         }
 
         Pass

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-VolumetricMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-StandardMover-VolumetricMesh.shader
@@ -144,7 +144,7 @@
 
         Tags
         {
-            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent""RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent""RenderPipeline" = "UniversalPipeline"
         }
         //Volumetric Pass
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-FixtureMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-FixtureMesh.shader
@@ -57,7 +57,7 @@
     {
         Tags
         {
-            "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "AlphaTest+1" "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline"
         }
 
         Pass

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-ProjectionMesh.shader
@@ -149,7 +149,7 @@
     {
         Tags
         {
-            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderPipeline" = "UniversalPipeline"
         }
 
         Pass

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-VolumetricMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/MovingLights/VRSL-WashMover-VolumetricMesh.shader
@@ -144,7 +144,7 @@
     {
         Tags
         {
-            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+2" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderPipeline" = "UniversalPipeline"
         }
         //Volumetric Pass
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/GenericUnlitTexture-Linear.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/GenericUnlitTexture-Linear.shader
@@ -10,7 +10,7 @@
     {
         Tags
         {
-            "RenderType"="Opaque" "RenderingPipeline"="UniversalPipeline"
+            "RenderType"="Opaque" "RenderPipeline"="UniversalPipeline"
         }
         LOD 100
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/GenericUnlitTexture.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/GenericUnlitTexture.shader
@@ -10,7 +10,7 @@
     {
         Tags
         {
-            "RenderType"="Opaque" "RenderingPipeline" = "UniversalPipeline"
+            "RenderType"="Opaque" "RenderPipeline" = "UniversalPipeline"
         }
         LOD 100
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Unlit.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/Other/VRSL-Unlit.shader
@@ -10,7 +10,7 @@ Shader "VRSL/Other/Unlit"
         Tags
         {
             "RenderType"="Opaque"
-            "RenderingPipeline"="UniversalPipeline"
+            "RenderPipeline"="UniversalPipeline"
         }
         LOD 100
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-LensFlare.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-LensFlare.shader
@@ -65,7 +65,7 @@
     {
         Tags
         {
-            "RenderType"="Transparent" "Queue" = "Transparent+200" "RenderingPipeline" = "UniversalPipeline"
+            "RenderType"="Transparent" "Queue" = "Transparent+200" "RenderPipeline" = "UniversalPipeline"
         }
         LOD 100
 

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-ProjectionMesh.shader
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Shaders/StaticLights/VRSL-StaticLight-ProjectionMesh.shader
@@ -87,7 +87,7 @@
     {
         Tags
         {
-            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderingPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent+1" "IgnoreProjector"="True" "RenderType" = "Transparent" "RenderPipeline" = "UniversalPipeline"
         }
         Pass
         {


### PR DESCRIPTION
This PR fixes URP subshaders using incorrect tags `"RenderingPipeline"` and changes them to use `"RenderPipeline"` instead. See https://docs.unity3d.com/2022.3/Documentation/Manual/SL-SubShaderTags.html for tag name references.

This typo causes some surface shaders to use ShadowCasters in URP subshaders instead of those generated from surface shaders in Built-in Rendering Pipeline (so it may affect for VRChat).