### PR TITLE
Update "Availble" typo in 3 files

### DIFF
--- a/Packages/com.acchosen.vr-stage-lighting/Editor/VRSL_UdonEditor.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Editor/VRSL_UdonEditor.cs
@@ -233,7 +233,7 @@ namespace VRSL.EditorScripts
 
             serializedObject.FindProperty("nineUniverseMode").boolValue = EditorGUILayout.Toggle(new GUIContent("Extended Universe Mode", 
             "Enables 9-Universe mode for this fixture. The grid will be split up by RGB channels with each section and color representing a universe." + 
-            " Only availble on the Vertical and Horizontal Grid nodes."), fixture.nineUniverseMode);
+            " Only available on the Vertical and Horizontal Grid nodes."), fixture.nineUniverseMode);
 
             serializedObject.FindProperty("enableFineChannels").boolValue = EditorGUILayout.Toggle(new GUIContent("Enable Fine Channels (For Pan/Tilt)",
             "Enables the computation of fine channels for pan and tilt. This allows for smoother movement of movers when using DMX control if your stream is stable enough to support it"), fixture.enableFineChannels);

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_DMX_Static.asset
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_DMX_Static.asset
@@ -390,7 +390,7 @@ MonoBehaviour:
     - Name: tooltip
       Entry: 1
       Data: Enables 9-Universe mode for this fixture. The grid will be split up by
-        RGB channels with each section and color representing a universe. Only availble
+        RGB channels with each section and color representing a universe. Only available
         on the Vertical and Horizontal Grid nodes.
     - Name: 
       Entry: 8

--- a/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_DMX_Static.cs
+++ b/Packages/com.acchosen.vr-stage-lighting/Runtime/Scripts/VRStageLighting_DMX_Static.cs
@@ -38,7 +38,7 @@ namespace VRSL
         public int dmxChannel = 1;
         [Tooltip ("The industry standard Artnet Universe. Use this to choose which universe to read the DMX Channel from.")]
         public int dmxUniverse = 1;
-        [Tooltip ("Enables 9-Universe mode for this fixture. The grid will be split up by RGB channels with each section and color representing a universe. Only availble on the Vertical and Horizontal Grid nodes.")]
+        [Tooltip ("Enables 9-Universe mode for this fixture. The grid will be split up by RGB channels with each section and color representing a universe. Only available on the Vertical and Horizontal Grid nodes.")]
         public bool nineUniverseMode;
 
         [Tooltip ("Enables the legacy 'Sector' based method of assigning DMX Channels. Keep this unchecked to use industry standard DMX Channels.")]


### PR DESCRIPTION
When scrolling thru the settings I saw Availble misspelled (it is supposed to be Available)

It bugged me, so in this PR it is fixed.
